### PR TITLE
add `Accept-Language` header

### DIFF
--- a/ProjBobcat/ProjBobcat/Class/Helper/HttpHelper.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/HttpHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
@@ -32,6 +33,8 @@ namespace ProjBobcat.Class.Helper
         public static async Task<string> Get(string address)
         {
             using var client = new HttpClient();
+            var acceptLanguage = new StringWithQualityHeaderValue(CultureInfo.CurrentCulture.Name);
+            client.DefaultRequestHeaders.AcceptLanguage.Add(acceptLanguage);
             return await client.GetStringAsync(new Uri(address)).ConfigureAwait(true);
         }
 
@@ -48,6 +51,8 @@ namespace ProjBobcat.Class.Helper
             using var client = new HttpClient();
             using var content = new StringContent(data);
             content.Headers.ContentType = new MediaTypeWithQualityHeaderValue(contentType);
+            var acceptLanguage = new StringWithQualityHeaderValue(CultureInfo.CurrentCulture.Name);
+            client.DefaultRequestHeaders.AcceptLanguage.Add(acceptLanguage);
             var response = await client.PostAsync(new Uri(address), content).ConfigureAwait(true);
             return response;
         }
@@ -65,6 +70,8 @@ namespace ProjBobcat.Class.Helper
             using var client = new HttpClient();
             using var content = new FormUrlEncodedContent(param);
             content.Headers.ContentType = new MediaTypeWithQualityHeaderValue(contentType);
+            var acceptLanguage = new StringWithQualityHeaderValue(CultureInfo.CurrentCulture.Name);
+            client.DefaultRequestHeaders.AcceptLanguage.Add(acceptLanguage);
             var response = await client.PostAsync(new Uri(address), content).ConfigureAwait(true);
             return response;
         }


### PR DESCRIPTION
这个 PR 会让启动器通过读取系统当前所使用的语言，并相应的设置 `Accept-Language` 头部。

这个 header 对于 Blessing Skin 来说是有用的。由于 Blessing Skin 支持多种语言，并且默认的 fallback 语言为英文，所以如果没有设置 `Accept-Language` 头部的话，Yggdrasil API 将会返回英文的消息。

即使这个 `HttpHelper` 会用于各种 HTTP 请求而并不一定用于 Yggdrasil API，并且不是所有使用 Yggdrasil API 的都一定使用 Blessing Skin，但大部分是，而添加了这个头部也不会带来什么坏处，因此是可行的。