### PR TITLE
Add Using

### DIFF
--- a/ProjBobcat/ProjBobcat/DefaultComponent/Launch/GameCore/DefaultMinecraftUWPCore.cs
+++ b/ProjBobcat/ProjBobcat/DefaultComponent/Launch/GameCore/DefaultMinecraftUWPCore.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Diagnostics;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using ProjBobcat.Class.Model;


### PR DESCRIPTION
`InvalidOperationException` requires `using System;`
`Process` requires `using System.Diagnostics;`

Sorry for not carefully checking the code just now.