### PR TITLE
minor fix

### DIFF
--- a/ProjBobcat/ProjBobcat/Class/Model/CurseForge/CurseForgeManifestModel.cs
+++ b/ProjBobcat/ProjBobcat/Class/Model/CurseForge/CurseForgeManifestModel.cs
@@ -16,7 +16,7 @@ public class CurseForgeManifestModel
 
     [JsonPropertyName("author")] public string? Author { get; set; }
 
-    [JsonPropertyName("files")] public required CurseForgeFileModel[] Files { get; init; }
+    [JsonPropertyName("files")] public CurseForgeFileModel[]? Files { get; init; }
 
     [JsonPropertyName("overrides")] public string? Overrides { get; set; }
 }

--- a/ProjBobcat/ProjBobcat/DefaultComponent/Installer/ModPackInstaller/CurseForgeInstaller.cs
+++ b/ProjBobcat/ProjBobcat/DefaultComponent/Installer/ModPackInstaller/CurseForgeInstaller.cs
@@ -97,7 +97,7 @@ public sealed class CurseForgeInstaller : ModPackInstallerBase, ICurseForgeInsta
         if (!di.Exists)
             di.Create();
 
-        NeedToDownload = manifest.Files.Length;
+        NeedToDownload = manifest.Files?.Length ?? 0;
 
         var urlBlock = new TransformManyBlock<IEnumerable<CurseForgeFileModel>, (long, long)>(urls =>
         {
@@ -185,7 +185,7 @@ public sealed class CurseForgeInstaller : ModPackInstallerBase, ICurseForgeInsta
 
         var linkOptions = new DataflowLinkOptions { PropagateCompletion = true };
         urlBlock.LinkTo(actionBlock, linkOptions);
-        urlBlock.Post(manifest.Files);
+        urlBlock.Post(manifest.Files ?? []);
         urlBlock.Complete();
 
         await actionBlock.Completion;


### PR DESCRIPTION
minor fix for mod pack installer

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to handle a nullable property in the `CurseForgeManifestModel` class and update its usage in the `CurseForgeInstaller` class.
- The `Files` property in `CurseForgeManifestModel` is now nullable.
- The usage of `manifest.Files` in the `CurseForgeInstaller` class has been updated to handle null values correctly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->