### PR TITLE
[Bugfix] Forge launch issue

### DIFF
--- a/ProjBobcat/ProjBobcat/Class/Model/MavenInfo.cs
+++ b/ProjBobcat/ProjBobcat/Class/Model/MavenInfo.cs
@@ -4,7 +4,7 @@
 ///     Maven包的有关信息。
 ///     Maven Package Information.
 /// </summary>
-public class MavenInfo
+public record MavenInfo
 {
     /// <summary>
     ///     组织名。


### PR DESCRIPTION
Bug fix for issue #105 

<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on improving the handling of Maven package information and fixing issues related to library JSON structure in different versions of Minecraft.

### Detailed summary:
- The `MavenInfo` class is now a record instead of a class.
- Added a fix for the new native format introduced in version 1.19 of Minecraft.
- Improved handling of library downloads and artifacts.
- Fixed a bug related to resolving Maven strings.
- Other minor improvements and bug fixes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->