### PR TITLE
[Bugfix] fix for old Forge launch

### DIFF
--- a/ProjBobcat/ProjBobcat/Class/Helper/MavenHelper.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/MavenHelper.cs
@@ -74,6 +74,10 @@ public static partial class MavenHelper
     /// <returns>拼接出来的Maven全称</returns>
     public static string GetMavenFullName(this MavenInfo? mavenInfo)
     {
-        return mavenInfo is null ? string.Empty : $"{mavenInfo.OrganizationName}.{mavenInfo.ArtifactId}";
+        return mavenInfo is null
+            ? string.Empty
+            : string.IsNullOrEmpty(mavenInfo.Classifier)
+                ? $"{mavenInfo.OrganizationName}.{mavenInfo.ArtifactId}"
+                : $"{mavenInfo.OrganizationName}.{mavenInfo.ArtifactId}.{mavenInfo.Classifier}";
     }
 }

--- a/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultVersionLocator.cs
+++ b/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultVersionLocator.cs
@@ -452,7 +452,8 @@ public sealed class DefaultVersionLocator : VersionLocatorBase
                             continue;
 
                         var lMaven = result.Libraries[j].Name!.ResolveMavenString()!;
-                        if (lMaven != mLMaven)
+
+                        if (!lMaven.GetMavenFullName().Equals(mLMaven.GetMavenFullName(), StringComparison.OrdinalIgnoreCase))
                             continue;
 
                         var v1 = new ComparableVersion(lMaven.Version);

--- a/ProjBobcat/ProjBobcat/ProjBobcat.csproj
+++ b/ProjBobcat/ProjBobcat/ProjBobcat.csproj
@@ -64,7 +64,7 @@ resolved the issue that LaunchWrapper may not return the correct exit code
   <!-- Dependencies -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.1" />
     <PackageReference Include="SharpCompress">
       <Version>0.35.0</Version>
     </PackageReference>


### PR DESCRIPTION
fix 1.16 Forge launch issue

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on improving the comparison of Maven strings and updating package references.

### Detailed summary:
- Improved the comparison of Maven strings in `DefaultVersionLocator.cs` by using `GetMavenFullName()` method.
- Updated the version of `Microsoft.Extensions.ObjectPool` package reference in `ProjBobcat.csproj` from `8.0.0` to `8.0.1`.
- Added a new condition in `GetMavenFullName()` method in `MavenHelper.cs` to handle the case when `mavenInfo.Classifier` is not empty.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->