### PR TITLE
[BugFix] minor fix for FileParser

### DIFF
--- a/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultLauncherAccountParser.cs
+++ b/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultLauncherAccountParser.cs
@@ -145,7 +145,7 @@ public class DefaultLauncherAccountParser : LauncherParserBase, ILauncherAccount
         var result = Find(id);
         if (!result.HasValue) return false;
 
-        var (key, value) = result.Value;
+        var (key, _) = result.Value;
 
         LauncherAccount?.Accounts?.Remove(key);
         Save();
@@ -155,13 +155,21 @@ public class DefaultLauncherAccountParser : LauncherParserBase, ILauncherAccount
 
     public void Save()
     {
-        if (File.Exists(_fullLauncherAccountPath))
-            File.Delete(_fullLauncherAccountPath);
-
         var launcherProfileJson =
             JsonSerializer.Serialize(LauncherAccount, typeof(LauncherAccountModel),
                 new LauncherAccountModelContext(JsonHelper.CamelCasePropertyNamesSettings()));
 
-        File.WriteAllText(_fullLauncherAccountPath, launcherProfileJson);
+        for (var i = 0; i < 3; i++)
+        {
+            try
+            {
+                File.WriteAllText(_fullLauncherAccountPath, launcherProfileJson);
+                break;
+            }
+            catch (IOException)
+            {
+                if (i == 2) throw;
+            }
+        }
     }
 }

--- a/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultLauncherProfileParser.cs
+++ b/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultLauncherProfileParser.cs
@@ -120,14 +120,22 @@ public sealed class DefaultLauncherProfileParser : LauncherParserBase, ILauncher
 
     public void SaveProfile()
     {
-        if (File.Exists(_fullLauncherProfilePath))
-            File.Delete(_fullLauncherProfilePath);
-
         var launcherProfileJson =
             JsonSerializer.Serialize(LauncherProfile, typeof(LauncherProfileModel),
                 new LauncherProfileModelContext(JsonHelper.CamelCasePropertyNamesSettings()));
 
-        File.WriteAllText(_fullLauncherProfilePath, launcherProfileJson);
+        for (var i = 0; i < 3; i++)
+        {
+            try
+            {
+                File.WriteAllText(_fullLauncherProfilePath, launcherProfileJson);
+                break;
+            }
+            catch (IOException)
+            {
+                if (i == 2) throw;
+            }
+        }
     }
 
     public void SelectGameProfile(string name)

--- a/ProjBobcat/ProjBobcat/ProjBobcat.csproj
+++ b/ProjBobcat/ProjBobcat/ProjBobcat.csproj
@@ -66,7 +66,7 @@ resolved the issue that LaunchWrapper may not return the correct exit code
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.1" />
     <PackageReference Include="SharpCompress">
-      <Version>0.35.0</Version>
+      <Version>0.36.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
minor fix for FileParser, added retry operation

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Updated the version of the `SharpCompress` package from `0.35.0` to `0.36.0`.
- Modified the `SaveProfile` method in the `DefaultLauncherProfileParser` class to retry writing the launcher profile file up to 3 times if there is an `IOException`.
- Modified the `RemoveAccount` method in the `DefaultLauncherAccountParser` class to use a discard variable instead of assigning the value to a variable.
- Modified the `Save` method in the `DefaultLauncherAccountParser` class to retry writing the launcher account file up to 3 times if there is an `IOException`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->