### PR TITLE
Bugfix: Fix NRE in DefaultLauncherAccountParser.cs

### DIFF
--- a/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultLauncherAccountParser.cs
+++ b/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultLauncherAccountParser.cs
@@ -143,9 +143,12 @@ public class DefaultLauncherAccountParser : LauncherParserBase, ILauncherAccount
     public bool RemoveAccount(Guid id)
     {
         var result = Find(id);
+
         if (!result.HasValue) return false;
 
         var (key, _) = result.Value;
+
+        if (string.IsNullOrEmpty(key)) return false;
 
         LauncherAccount?.Accounts?.Remove(key);
         Save();


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a check for empty or null key before removing an account from the LauncherAccount's Accounts collection. 

### Detailed summary
- Added a check for empty or null key before removing an account from LauncherAccount's Accounts collection.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->