### PR TITLE
[BugFix & Improvements] add support for legacy game natives replacement

### DIFF
--- a/ProjBobcat/ProjBobcat/Class/Helper/AuthPropertyHelper.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/AuthPropertyHelper.cs
@@ -9,9 +9,7 @@ using ProjBobcat.Class.Model.YggdrasilAuth;
 namespace ProjBobcat.Class.Helper;
 
 [JsonSerializable(typeof(Dictionary<string, string[]>))]
-partial class UserPropertiesContext : JsonSerializerContext
-{
-}
+partial class UserPropertiesContext : JsonSerializerContext;
 
 /// <summary>
 ///     AuthProperty工具类

--- a/ProjBobcat/ProjBobcat/Class/Helper/EncodingHelper.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/EncodingHelper.cs
@@ -7,46 +7,44 @@ public static class EncodingHelper
 {
     public static Encoding GuessEncoding(string input)
     {
-        switch (input.Length)
-        {
-            // Try UTF-8 with BOM
-            case >= 3 when input[0] == 0xEF && input[1] == 0xBB && input[2] == 0xBF:
-                return Encoding.UTF8;
-            // Try UTF-32 with BOM
-            case >= 4 when
-                input[0] == 0xFF && input[1] == 0xFE && input[2] == 0 && input[3] == 0:
-                return Encoding.UTF32;
-            // Try UTF-16 Big Endian with BOM
-            case >= 2 when input[0] == 0xFE && input[1] == 0xFF:
-                return Encoding.BigEndianUnicode;
-            // Try UTF-16 Little Endian with BOM
-            case >= 2 when input[0] == 0xFF && input[1] == 0xFE:
-                return Encoding.Unicode;
-            // Try UTF-7
-            case >= 5 when input.StartsWith("+/v", StringComparison.Ordinal):
-                return Encoding.UTF7;
-        }
+        if (IsUtf8(input)) return Encoding.UTF8;
+        if (IsUtf32(input)) return Encoding.UTF32;
+        if (IsBigEndianUnicode(input)) return Encoding.BigEndianUnicode;
+        if (IsUnicode(input)) return Encoding.Unicode;
+        if (IsUtf7(input)) return Encoding.UTF7;
+        if (IsGb2312(input)) return Encoding.GetEncoding("GB2312");
+        if (IsGbk(input)) return Encoding.GetEncoding("GBK");
+        if (IsGb18030(input)) return Encoding.GetEncoding("GB18030");
 
-        // Try GB2312
-        if (IsGB2312(input))
-        {
-            return Encoding.GetEncoding("GB2312");
-        }
-
-        // Try GBK
-        if (IsGBK(input))
-        {
-            return Encoding.GetEncoding("GBK");
-        }
-
-        // Try GB18030
-        return IsGB18030(input)
-            ? Encoding.GetEncoding("GB18030")
-            // If none of the above, try ASCII
-            : Encoding.ASCII;
+        return Encoding.ASCII;
     }
 
-    static bool IsGB2312(string input)
+    static bool IsUtf7(string input)
+    {
+        return input.Length >= 5 && input.StartsWith("+/v", StringComparison.Ordinal);
+    }
+
+    static bool IsUnicode(string input)
+    {
+        return input.Length >= 2 && input[0] == 0xFF && input[1] == 0xFE;
+    }
+
+    static bool IsBigEndianUnicode(string input)
+    {
+        return input.Length >= 2 && input[0] == 0xFE && input[1] == 0xFF;
+    }
+
+    static bool IsUtf32(string input)
+    {
+        return input.Length >= 4 && input[0] == 0xFF && input[1] == 0xFE && input[2] == 0 && input[3] == 0;
+    }
+
+    static bool IsUtf8(string input)
+    {
+        return input.Length >= 3 && input[0] == 0xEF && input[1] == 0xBB && input[2] == 0xBF;
+    }
+
+    static bool IsGb2312(string input)
     {
         try
         {
@@ -59,7 +57,7 @@ public static class EncodingHelper
         }
     }
 
-    static bool IsGBK(string input)
+    static bool IsGbk(string input)
     {
         try
         {
@@ -72,7 +70,7 @@ public static class EncodingHelper
         }
     }
 
-    static bool IsGB18030(string input)
+    static bool IsGb18030(string input)
     {
         try
         {

--- a/ProjBobcat/ProjBobcat/Class/Helper/EncodingHelper.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/EncodingHelper.cs
@@ -1,0 +1,87 @@
+﻿using System.Text;
+using System;
+
+namespace ProjBobcat.Class.Helper;
+
+public static class EncodingHelper
+{
+    public static Encoding GuessEncoding(string input)
+    {
+        switch (input.Length)
+        {
+            // Try UTF-8 with BOM
+            case >= 3 when input[0] == 0xEF && input[1] == 0xBB && input[2] == 0xBF:
+                return Encoding.UTF8;
+            // Try UTF-32 with BOM
+            case >= 4 when
+                input[0] == 0xFF && input[1] == 0xFE && input[2] == 0 && input[3] == 0:
+                return Encoding.UTF32;
+            // Try UTF-16 Big Endian with BOM
+            case >= 2 when input[0] == 0xFE && input[1] == 0xFF:
+                return Encoding.BigEndianUnicode;
+            // Try UTF-16 Little Endian with BOM
+            case >= 2 when input[0] == 0xFF && input[1] == 0xFE:
+                return Encoding.Unicode;
+            // Try UTF-7
+            case >= 5 when input.StartsWith("+/v", StringComparison.Ordinal):
+                return Encoding.UTF7;
+        }
+
+        // Try GB2312
+        if (IsGB2312(input))
+        {
+            return Encoding.GetEncoding("GB2312");
+        }
+
+        // Try GBK
+        if (IsGBK(input))
+        {
+            return Encoding.GetEncoding("GBK");
+        }
+
+        // Try GB18030
+        return IsGB18030(input)
+            ? Encoding.GetEncoding("GB18030")
+            // If none of the above, try ASCII
+            : Encoding.ASCII;
+    }
+
+    static bool IsGB2312(string input)
+    {
+        try
+        {
+            Encoding.GetEncoding("GB2312").GetBytes(input);
+            return true;
+        }
+        catch (EncoderFallbackException)
+        {
+            return false;
+        }
+    }
+
+    static bool IsGBK(string input)
+    {
+        try
+        {
+            Encoding.GetEncoding("GBK").GetBytes(input);
+            return true;
+        }
+        catch (EncoderFallbackException)
+        {
+            return false;
+        }
+    }
+
+    static bool IsGB18030(string input)
+    {
+        try
+        {
+            Encoding.GetEncoding("GB18030").GetBytes(input);
+            return true;
+        }
+        catch (EncoderFallbackException)
+        {
+            return false;
+        }
+    }
+}

--- a/ProjBobcat/ProjBobcat/Class/Helper/GameResourcesResolveHelper.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/GameResourcesResolveHelper.cs
@@ -17,6 +17,125 @@ namespace ProjBobcat.Class.Helper;
 
 public static class GameResourcesResolveHelper
 {
+    static async Task<GameModResolvedInfo?> GetLegacyModInfo(
+        IArchiveEntry entry,
+        string file,
+        bool isEnabled)
+    {
+        await using var stream = entry.OpenEntryStream();
+        using var sR = new StreamReader(stream);
+        using var parser = new TOMLParser.TOMLParser(sR);
+        var pResult = parser.TryParse(out var table, out _);
+
+        if (!pResult) return null;
+        if (!table.HasKey("mods")) return null;
+
+        var innerTable = table["mods"];
+
+        if (innerTable is not TomlArray arr) return null;
+        if (arr.ChildrenCount == 0) return null;
+
+        var infoTable = arr.Children.First();
+
+        var title = infoTable.HasKey("modId")
+            ? (infoTable["modId"]?.AsString ?? "-")
+            : Path.GetFileName(file);
+        var author = infoTable.HasKey("authors")
+            ? infoTable["authors"]?.AsString
+            : null;
+        var version = infoTable.HasKey("version")
+            ? infoTable["version"]?.AsString
+            : null;
+
+        return new GameModResolvedInfo(author?.Value, file, null, title, version?.Value, "Forge", isEnabled);
+    }
+
+    static async Task<GameModResolvedInfo?> GetNewModInfo(
+        IArchiveEntry entry,
+        string file,
+        bool isEnabled,
+        CancellationToken ct)
+    {
+        List<GameModInfoModel>? model = null;
+
+        await using var stream = entry.OpenEntryStream();
+        var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+
+        switch (doc.RootElement.ValueKind)
+        {
+            case JsonValueKind.Object:
+                var val = doc.RootElement.Deserialize(GameModInfoModelContext.Default.GameModInfoModel);
+
+                if (val != null) model = [val];
+
+                break;
+            case JsonValueKind.Array:
+                model = doc.RootElement.Deserialize(GameModInfoModelContext.Default.ListGameModInfoModel) ?? [];
+                break;
+        }
+
+        if (model == null || model.Count == 0)
+            return null;
+
+        var authors = new HashSet<string>();
+        foreach (var author in model.Where(m => m.AuthorList != null).SelectMany(m => m.AuthorList!))
+            authors.Add(author);
+
+        var baseMod = model.FirstOrDefault(m => string.IsNullOrEmpty(m.Parent));
+
+        if (baseMod == null)
+        {
+            baseMod = model.First();
+            model.RemoveAt(0);
+        }
+        else
+        {
+            model.Remove(baseMod);
+        }
+
+        var authorStr = string.Join(',', authors);
+        var authorResult = string.IsNullOrEmpty(authorStr) ? null : authorStr;
+        var modList = model.Where(m => !string.IsNullOrEmpty(m.Name)).Select(m => m.Name!).ToImmutableList();
+        var titleResult = string.IsNullOrEmpty(baseMod.Name) ? Path.GetFileName(file) : baseMod.Name;
+
+        var displayModel = new GameModResolvedInfo(authorResult, file, modList, titleResult, baseMod.Version,
+            "Forge *", isEnabled);
+
+        return displayModel;
+    }
+
+    static async Task<GameModResolvedInfo> GetFabricModInfo(
+        IArchiveEntry entry,
+        string file,
+        bool isEnabled,
+        CancellationToken ct)
+    {
+        try
+        {
+            await using var stream = entry.OpenEntryStream();
+            var tempModel = await JsonSerializer.DeserializeAsync(stream,
+                FabricModInfoModelContext.Default.FabricModInfoModel, ct);
+
+            var author = tempModel?.Authors is { Length: > 0 }
+                ? string.Join(',', tempModel.Authors)
+                : null;
+            var modList = tempModel?.Depends?.Select(d => d.Key)?.ToImmutableList();
+            var titleResult = string.IsNullOrEmpty(tempModel?.Id) ? Path.GetFileName(file) : tempModel.Id;
+            var versionResult = string.IsNullOrEmpty(tempModel?.Version) ? null : tempModel.Version;
+
+            return new GameModResolvedInfo(author, file, modList, titleResult, versionResult, "Fabric", isEnabled);
+        }
+        catch (JsonException e)
+        {
+            var errorList = new[]
+            {
+                "[!] 数据包 JSON 异常",
+                e.Message
+            };
+            return new GameModResolvedInfo(null, file, errorList.ToImmutableList(), Path.GetFileName(file), null, "Fabric", isEnabled);
+        }
+    }
+
     public static async IAsyncEnumerable<GameModResolvedInfo> ResolveModListAsync(
         IEnumerable<string> files,
         [EnumeratorCancellation] CancellationToken ct)
@@ -50,21 +169,21 @@ public static class GameResourcesResolveHelper
 
             if (modInfoEntry != null)
             {
-                result = await GetNewModInfo(modInfoEntry);
+                result = await GetNewModInfo(modInfoEntry, file, isEnabled, ct);
                 
                 if (result != null) goto ReturnResult;
             }
 
             if (tomlInfoEntry != null)
             {
-                result = await GetLegacyModInfo(tomlInfoEntry);
+                result = await GetLegacyModInfo(tomlInfoEntry, file, isEnabled);
 
                 if (result != null) goto ReturnResult;
             }
 
             if (fabricModInfoEntry != null)
             {
-                result = await GetFabricModInfo(fabricModInfoEntry);
+                result = await GetFabricModInfo(fabricModInfoEntry, file, isEnabled, ct);
                 goto ReturnResult;
             }
 
@@ -79,215 +198,109 @@ public static class GameResourcesResolveHelper
 
             ReturnResult:
             yield return result;
+        }
+    }
 
-            continue;
+    static async Task<GameResourcePackResolvedInfo?> ResolveResPackFile(
+        string file,
+        CancellationToken ct)
+    {
+        var ext = Path.GetExtension(file);
 
-            async Task<GameModResolvedInfo> GetFabricModInfo(IArchiveEntry entry)
+        if (!ext.Equals(".zip", StringComparison.OrdinalIgnoreCase)) return null;
+        if (!ArchiveHelper.TryOpen(file, out var archive)) return null;
+        if (archive == null) return null;
+
+        var packIconEntry =
+            archive.Entries.FirstOrDefault(e => e.Key.Equals("pack.png", StringComparison.OrdinalIgnoreCase));
+        var packInfoEntry = archive.Entries.FirstOrDefault(e =>
+            e.Key.Equals("pack.mcmeta", StringComparison.OrdinalIgnoreCase));
+
+        var fileName = Path.GetFileName(file);
+        byte[]? imageBytes;
+        string? description = null;
+        var version = -1;
+
+        if (packIconEntry != null)
+        {
+            await using var stream = packIconEntry.OpenEntryStream();
+            await using var ms = new MemoryStream();
+            await stream.CopyToAsync(ms, ct);
+
+            imageBytes = ms.ToArray();
+        }
+        else
+        {
+            return null;
+        }
+
+        if (packInfoEntry != null)
+        {
+            try
             {
-                try
-                {
-                    await using var stream = entry.OpenEntryStream();
-                    var tempModel = await JsonSerializer.DeserializeAsync(stream,
-                        FabricModInfoModelContext.Default.FabricModInfoModel, ct);
+                await using var stream = packInfoEntry.OpenEntryStream();
+                var model = await JsonSerializer.DeserializeAsync(stream,
+                    GameResourcePackModelContext.Default.GameResourcePackModel, ct);
 
-                    var author = tempModel?.Authors is { Length: > 0 }
-                        ? string.Join(',', tempModel.Authors)
-                        : null;
-                    var modList = tempModel?.Depends?.Select(d => d.Key)?.ToImmutableList();
-                    var titleResult = string.IsNullOrEmpty(tempModel?.Id) ? Path.GetFileName(file) : tempModel.Id;
-                    var versionResult = string.IsNullOrEmpty(tempModel?.Version) ? null : tempModel.Version;
-
-                    return new GameModResolvedInfo(author, file, modList, titleResult, versionResult, "Fabric", isEnabled);
-                }
-                catch (JsonException e)
-                {
-                    var errorList = new[]
-                    {
-                        "[!] 数据包 JSON 异常",
-                        e.Message
-                    };
-                    return new GameModResolvedInfo(null, file, errorList.ToImmutableList(), Path.GetFileName(file), null, "Fabric", isEnabled);
-                }
+                description = model?.Pack?.Description;
+                version = model?.Pack?.PackFormat ?? -1;
             }
-
-            async Task<GameModResolvedInfo?> GetNewModInfo(IArchiveEntry entry)
+            catch (JsonException e)
             {
-                List<GameModInfoModel>? model = null;
-                
-                await using var stream = entry.OpenEntryStream();
-                var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
-                
-                switch (doc.RootElement.ValueKind)
-                {
-                    case JsonValueKind.Object:
-                        var val = doc.RootElement.Deserialize(GameModInfoModelContext.Default.GameModInfoModel);
-
-                        if (val != null) model = [val];
-
-                        break;
-                    case JsonValueKind.Array:
-                        model = doc.RootElement.Deserialize(GameModInfoModelContext.Default.ListGameModInfoModel) ?? [];
-                        break;
-                }
-
-                if (model == null || model.Count == 0)
-                    return null;
-
-                var authors = new HashSet<string>();
-                foreach (var author in model.Where(m => m.AuthorList != null).SelectMany(m => m.AuthorList!))
-                    authors.Add(author);
-
-                var baseMod = model.FirstOrDefault(m => string.IsNullOrEmpty(m.Parent));
-
-                if (baseMod == null)
-                {
-                    baseMod = model.First();
-                    model.RemoveAt(0);
-                }
-                else
-                {
-                    model.Remove(baseMod);
-                }
-
-                var authorStr = string.Join(',', authors);
-                var authorResult = string.IsNullOrEmpty(authorStr) ? null : authorStr;
-                var modList = model.Where(m => !string.IsNullOrEmpty(m.Name)).Select(m => m.Name!).ToImmutableList();
-                var titleResult = string.IsNullOrEmpty(baseMod.Name) ? Path.GetFileName(file) : baseMod.Name;
-
-                var displayModel = new GameModResolvedInfo(authorResult, file, modList, titleResult, baseMod.Version,
-                    "Forge *", isEnabled);
-
-                return displayModel;
-            }
-
-            async Task<GameModResolvedInfo?> GetLegacyModInfo(IArchiveEntry entry)
-            {
-                await using var stream = entry.OpenEntryStream();
-                using var sR = new StreamReader(stream);
-                using var parser = new TOMLParser.TOMLParser(sR);
-                var pResult = parser.TryParse(out var table, out _);
-
-                if (!pResult) return null;
-                if (!table.HasKey("mods")) return null;
-
-                var innerTable = table["mods"];
-
-                if (innerTable is not TomlArray arr) return null;
-                if (arr.ChildrenCount == 0) return null;
-
-                var infoTable = arr.Children.First();
-
-                var title = infoTable.HasKey("modId")
-                    ? (infoTable["modId"]?.AsString ?? "-")
-                    : Path.GetFileName(file);
-                var author = infoTable.HasKey("authors")
-                    ? infoTable["authors"]?.AsString
-                    : null;
-                var version = infoTable.HasKey("version")
-                    ? infoTable["version"]?.AsString
-                    : null;
-
-                return new GameModResolvedInfo(author?.Value, file, null, title, version?.Value, "Forge", isEnabled);
+                description = $"[!] 数据包 JSON 异常: {e.Message}";
+                version = -1;
             }
         }
+
+        return new GameResourcePackResolvedInfo(fileName, description, version, imageBytes);
+    }
+
+    static async Task<GameResourcePackResolvedInfo?> ResolveResPackDir(
+        string dir,
+        CancellationToken ct)
+    {
+        var iconPath = Path.Combine(dir, "pack.png");
+        var infoPath = Path.Combine(dir, "pack.mcmeta");
+
+        if (!File.Exists(iconPath)) return null;
+
+        var fileName = dir.Split('\\').Last();
+        var imageBytes = await File.ReadAllBytesAsync(iconPath, ct);
+        string? description = null;
+        var version = -1;
+
+        if (File.Exists(infoPath))
+        {
+            try
+            {
+                await using var contentStream = File.OpenRead(infoPath);
+                var model = await JsonSerializer.DeserializeAsync(contentStream,
+                    GameResourcePackModelContext.Default.GameResourcePackModel, ct);
+
+                description = model?.Pack?.Description;
+                version = model?.Pack?.PackFormat ?? -1;
+            }
+            catch (JsonException e)
+            {
+                description = $"[!] 数据包 JSON 异常: {e.Message}";
+                version = -1;
+            }
+        }
+
+        return new GameResourcePackResolvedInfo(fileName, description, version, imageBytes);
     }
 
     public static async IAsyncEnumerable<GameResourcePackResolvedInfo> ResolveResourcePackAsync(
         IEnumerable<(string, bool)> files,
         [EnumeratorCancellation] CancellationToken ct)
     {
-        async Task<GameResourcePackResolvedInfo?> ResolveResPackFile(string file)
-        {
-            var ext = Path.GetExtension(file);
-
-            if (!ext.Equals(".zip", StringComparison.OrdinalIgnoreCase)) return null;
-            if (!ArchiveHelper.TryOpen(file, out var archive)) return null;
-            if (archive == null) return null;
-
-            var packIconEntry =
-                archive.Entries.FirstOrDefault(e => e.Key.Equals("pack.png", StringComparison.OrdinalIgnoreCase));
-            var packInfoEntry = archive.Entries.FirstOrDefault(e =>
-                e.Key.Equals("pack.mcmeta", StringComparison.OrdinalIgnoreCase));
-
-            var fileName = Path.GetFileName(file);
-            byte[]? imageBytes;
-            string? description = null;
-            var version = -1;
-
-            if (packIconEntry != null)
-            {
-                await using var stream = packIconEntry.OpenEntryStream();
-                await using var ms = new MemoryStream();
-                await stream.CopyToAsync(ms, ct);
-
-                imageBytes = ms.ToArray();
-            }
-            else
-            {
-                return null;
-            }
-
-            if (packInfoEntry != null)
-            {
-                try
-                {
-                    await using var stream = packInfoEntry.OpenEntryStream();
-                    var model = await JsonSerializer.DeserializeAsync(stream,
-                        GameResourcePackModelContext.Default.GameResourcePackModel, ct);
-
-                    description = model?.Pack?.Description;
-                    version = model?.Pack?.PackFormat ?? -1;
-                }
-                catch (JsonException e)
-                {
-                    description = $"[!] 数据包 JSON 异常: {e.Message}";
-                    version = -1;
-                }
-            }
-
-            return new GameResourcePackResolvedInfo(fileName, description, version, imageBytes);
-        }
-
-        async Task<GameResourcePackResolvedInfo?> ResolveResPackDir(string dir)
-        {
-            var iconPath = Path.Combine(dir, "pack.png");
-            var infoPath = Path.Combine(dir, "pack.mcmeta");
-
-            if (!File.Exists(iconPath)) return null;
-
-            var fileName = dir.Split('\\').Last();
-            var imageBytes = await File.ReadAllBytesAsync(iconPath, ct);
-            string? description = null;
-            var version = -1;
-
-            if (File.Exists(infoPath))
-            {
-                try
-                {
-                    await using var contentStream = File.OpenRead(infoPath);
-                    var model = await JsonSerializer.DeserializeAsync(contentStream,
-                        GameResourcePackModelContext.Default.GameResourcePackModel, ct);
-
-                    description = model?.Pack?.Description;
-                    version = model?.Pack?.PackFormat ?? -1;
-                }
-                catch (JsonException e)
-                {
-                    description = $"[!] 数据包 JSON 异常: {e.Message}";
-                    version = -1;
-                }
-            }
-
-            return new GameResourcePackResolvedInfo(fileName, description, version, imageBytes);
-        }
-
         foreach (var (path, isDir) in files)
         {
             if (ct.IsCancellationRequested) yield break;
 
             if (!isDir)
             {
-                var result = await ResolveResPackFile(path);
+                var result = await ResolveResPackFile(path, ct);
 
                 if (result == null) continue;
 
@@ -295,7 +308,7 @@ public static class GameResourcesResolveHelper
             }
             else
             {
-                var result = await ResolveResPackDir(path);
+                var result = await ResolveResPackDir(path, ct);
 
                 if (result == null) continue;
 
@@ -304,30 +317,31 @@ public static class GameResourcesResolveHelper
         }
     }
 
-    public static IEnumerable<GameShaderPackResolvedInfo> ResolveShaderPack(IEnumerable<(string, bool)> paths,
+    static GameShaderPackResolvedInfo? ResolveShaderPackFile(string file)
+    {
+        if (!ArchiveHelper.TryOpen(file, out var archive)) return null;
+        if (archive == null) return null;
+        if (!archive.Entries.Any(e => e.Key.StartsWith("shaders/", StringComparison.OrdinalIgnoreCase)))
+            return null;
+
+        var model = new GameShaderPackResolvedInfo(Path.GetFileName(file), false);
+
+        return model;
+    }
+
+    static GameShaderPackResolvedInfo? ResolveShaderPackDir(string dir)
+    {
+        var shaderPath = Path.Combine(dir, "shaders");
+
+        if (!Directory.Exists(shaderPath)) return null;
+
+        return new GameShaderPackResolvedInfo(dir.Split('\\').Last(), true);
+    }
+
+    public static IEnumerable<GameShaderPackResolvedInfo> ResolveShaderPack(
+        IEnumerable<(string, bool)> paths,
         CancellationToken ct)
     {
-        GameShaderPackResolvedInfo? ResolveShaderPackFile(string file)
-        {
-            if (!ArchiveHelper.TryOpen(file, out var archive)) return null;
-            if (archive == null) return null;
-            if (!archive.Entries.Any(e => e.Key.StartsWith("shaders/", StringComparison.OrdinalIgnoreCase)))
-                return null;
-
-            var model = new GameShaderPackResolvedInfo(Path.GetFileName(file), false);
-
-            return model;
-        }
-
-        GameShaderPackResolvedInfo? ResolveShaderPackDir(string dir)
-        {
-            var shaderPath = Path.Combine(dir, "shaders");
-
-            if (!Directory.Exists(shaderPath)) return null;
-
-            return new GameShaderPackResolvedInfo(dir.Split('\\').Last(), true);
-        }
-
         foreach (var (path, isDir) in paths)
         {
             if (ct.IsCancellationRequested) yield break;

--- a/ProjBobcat/ProjBobcat/Class/Helper/GameVersionHelper.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/GameVersionHelper.cs
@@ -1,0 +1,89 @@
+﻿using ProjBobcat.Class.Model;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System;
+using System.Linq;
+using System.Text.Json;
+
+namespace ProjBobcat.Class.Helper;
+
+public static partial class GameVersionHelper
+{
+    [GeneratedRegex(@"1.\d{1,2}.\d{1,2}")]
+    private static partial Regex McVersionMatch();
+
+    public static string? TryGetMcVersion(List<RawVersionModel> versions)
+    {
+        foreach (var version in versions)
+        {
+            var mcVersion = TryGetMcVersionByForgeGameArgs(version) ??
+                            TryGetMcVersionByFabric(version) ??
+                            TryGetMcVersionByOptifine(version) ??
+                            TryGetMcVersionByInheritFrom(version) ??
+                            TryGetMcVersionById(version);
+
+            if (string.IsNullOrEmpty(mcVersion)) continue;
+            if (!McVersionMatch().IsMatch(mcVersion)) continue;
+
+            return mcVersion;
+        }
+
+        return null;
+    }
+
+    private static string TryGetMcVersionById(RawVersionModel version)
+    {
+        return version.Id;
+    }
+
+    private static string? TryGetMcVersionByInheritFrom(RawVersionModel version)
+    {
+        return version.InheritsFrom;
+    }
+
+    private static string? TryGetMcVersionByForgeGameArgs(RawVersionModel version)
+    {
+        var gameArgs = version.Arguments?.Game?
+            .Where(arg => arg.ValueKind == JsonValueKind.String)
+            .Select(arg => arg.GetString())
+            .OfType<string>()
+            .ToList();
+
+        if (gameArgs == null) return null;
+
+        var containsForgeArgs = gameArgs.Contains("--fml.forgeVersion", StringComparer.OrdinalIgnoreCase) &&
+                                gameArgs.Contains("--fml.mcVersion", StringComparer.OrdinalIgnoreCase);
+
+        if (!containsForgeArgs) return null;
+
+        var mcVersion = gameArgs[gameArgs.IndexOf("--fml.mcVersion") + 1];
+
+        return mcVersion;
+    }
+
+    private static string? TryGetMcVersionByFabric(RawVersionModel version)
+    {
+        const string fabricLibPrefix = "net.fabricmc:intermediary:";
+
+        var fabricLib = version.Libraries
+            .FirstOrDefault(lib => lib.Name.StartsWith(fabricLibPrefix, StringComparison.OrdinalIgnoreCase));
+
+        var mcVersion = fabricLib?.Name[fabricLibPrefix.Length..];
+
+        return mcVersion;
+    }
+
+    private static string? TryGetMcVersionByOptifine(RawVersionModel version)
+    {
+        const string optifineLibPrefix = "optifine:OptiFine:";
+
+        var optifineLib = version.Libraries
+            .FirstOrDefault(lib => lib.Name.StartsWith(optifineLibPrefix, StringComparison.OrdinalIgnoreCase));
+
+        var mcVersion = optifineLib?.Name[optifineLibPrefix.Length..]
+            .Split('_', StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault();
+
+        return mcVersion;
+    }
+}

--- a/ProjBobcat/ProjBobcat/Class/Helper/NativeReplace/NativeReplaceHelper.Json.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/NativeReplace/NativeReplaceHelper.Json.cs
@@ -1,0 +1,3954 @@
+﻿namespace ProjBobcat.Class.Helper.NativeReplace;
+
+public static partial class NativeReplaceHelper
+{
+    const string ReplaceDicJson = """
+                                   {
+                                    "linux-arm64": {
+                                      "org.lwjgl:lwjgl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2.jar",
+                                            "sha1": "4421d94af68e35dcaa31737a6fc59136a1e61b94",
+                                            "size": 786196
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "8bd89332c90a90e6bc4aa997a25c05b7db02c90a",
+                                            "size": 90795
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2.jar",
+                                            "sha1": "877e17e39ebcd58a9c956dc3b5b777813de0873a",
+                                            "size": 43233
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "5249f18a9ae20ea86c5816bc3107a888ce7a17d2",
+                                            "size": 206402
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2.jar",
+                                            "sha1": "ae5357ed6d934546d3533993ea84c0cfb75eed95",
+                                            "size": 108230
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "22408980cc579709feaf9acb807992d3ebcf693f",
+                                            "size": 590865
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2.jar",
+                                            "sha1": "ee8e95be0b438602038bc1f02dc5e3d011b1b216",
+                                            "size": 928871
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "bb9eb56da6d1d549d6a767218e675e36bc568eb9",
+                                            "size": 58627
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2.jar",
+                                            "sha1": "757920418805fb90bfebb3d46b1d9e7669fca2eb",
+                                            "size": 135828
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "bc49e64bae0f7ff103a312ee8074a34c4eb034c7",
+                                            "size": 120168
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2.jar",
+                                            "sha1": "a2550795014d622b686e9caac50b14baa87d2c70",
+                                            "size": 118874
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "11a380c37b0f03cb46db235e064528f84d736ff7",
+                                            "size": 207419
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2.jar",
+                                            "sha1": "9f65c248dd77934105274fcf8351abb75b34327c",
+                                            "size": 13404
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "93f8c5bc1984963cd79109891fb5a9d1e580373e",
+                                            "size": 43381
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2.jar",
+                                            "sha1": "4421d94af68e35dcaa31737a6fc59136a1e61b94",
+                                            "size": 786196
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "8bd89332c90a90e6bc4aa997a25c05b7db02c90a",
+                                            "size": 90795
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2.jar",
+                                            "sha1": "877e17e39ebcd58a9c956dc3b5b777813de0873a",
+                                            "size": 43233
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "5249f18a9ae20ea86c5816bc3107a888ce7a17d2",
+                                            "size": 206402
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2.jar",
+                                            "sha1": "ae5357ed6d934546d3533993ea84c0cfb75eed95",
+                                            "size": 108230
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "22408980cc579709feaf9acb807992d3ebcf693f",
+                                            "size": 590865
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2.jar",
+                                            "sha1": "ee8e95be0b438602038bc1f02dc5e3d011b1b216",
+                                            "size": 928871
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "bb9eb56da6d1d549d6a767218e675e36bc568eb9",
+                                            "size": 58627
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2.jar",
+                                            "sha1": "757920418805fb90bfebb3d46b1d9e7669fca2eb",
+                                            "size": 135828
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "bc49e64bae0f7ff103a312ee8074a34c4eb034c7",
+                                            "size": 120168
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2.jar",
+                                            "sha1": "a2550795014d622b686e9caac50b14baa87d2c70",
+                                            "size": 118874
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "11a380c37b0f03cb46db235e064528f84d736ff7",
+                                            "size": 207419
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2.jar",
+                                            "sha1": "9f65c248dd77934105274fcf8351abb75b34327c",
+                                            "size": 13404
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "93f8c5bc1984963cd79109891fb5a9d1e580373e",
+                                            "size": 43381
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.3.1": {
+                                        "name": "org.lwjgl:lwjgl:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2.jar",
+                                            "sha1": "4421d94af68e35dcaa31737a6fc59136a1e61b94",
+                                            "size": 786196
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "8bd89332c90a90e6bc4aa997a25c05b7db02c90a",
+                                            "size": 90795
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.3.1": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2.jar",
+                                            "sha1": "877e17e39ebcd58a9c956dc3b5b777813de0873a",
+                                            "size": 43233
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "5249f18a9ae20ea86c5816bc3107a888ce7a17d2",
+                                            "size": 206402
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.3.1": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2.jar",
+                                            "sha1": "ae5357ed6d934546d3533993ea84c0cfb75eed95",
+                                            "size": 108230
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "22408980cc579709feaf9acb807992d3ebcf693f",
+                                            "size": 590865
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.3.1": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2.jar",
+                                            "sha1": "ee8e95be0b438602038bc1f02dc5e3d011b1b216",
+                                            "size": 928871
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "bb9eb56da6d1d549d6a767218e675e36bc568eb9",
+                                            "size": 58627
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.3.1": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2.jar",
+                                            "sha1": "757920418805fb90bfebb3d46b1d9e7669fca2eb",
+                                            "size": 135828
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "bc49e64bae0f7ff103a312ee8074a34c4eb034c7",
+                                            "size": 120168
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.3.1": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2.jar",
+                                            "sha1": "a2550795014d622b686e9caac50b14baa87d2c70",
+                                            "size": 118874
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "11a380c37b0f03cb46db235e064528f84d736ff7",
+                                            "size": 207419
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.3.1": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2.jar",
+                                            "sha1": "9f65c248dd77934105274fcf8351abb75b34327c",
+                                            "size": 13404
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "93f8c5bc1984963cd79109891fb5a9d1e580373e",
+                                            "size": 43381
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "8bd89332c90a90e6bc4aa997a25c05b7db02c90a",
+                                            "size": 90795
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "5249f18a9ae20ea86c5816bc3107a888ce7a17d2",
+                                            "size": 206402
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "22408980cc579709feaf9acb807992d3ebcf693f",
+                                            "size": 590865
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "bb9eb56da6d1d549d6a767218e675e36bc568eb9",
+                                            "size": 58627
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "bc49e64bae0f7ff103a312ee8074a34c4eb034c7",
+                                            "size": 120168
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "11a380c37b0f03cb46db235e064528f84d736ff7",
+                                            "size": 207419
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.2:natives-linux-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-linux-arm64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-linux-arm64.jar",
+                                            "sha1": "93f8c5bc1984963cd79109891fb5a9d1e580373e",
+                                            "size": 43381
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.0:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-arm64": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3/lwjgl2-natives-2.9.3-linux-arm64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-linux-arm64/lwjgl2-natives-2.9.3-linux-arm64.jar",
+                                              "sha1": "c47df34b6a0414b2d9972f602d0c85191129d69c",
+                                              "size": 7346768
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-arm64"
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.1:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-arm64": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3/lwjgl2-natives-2.9.3-linux-arm64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-linux-arm64/lwjgl2-natives-2.9.3-linux-arm64.jar",
+                                              "sha1": "c47df34b6a0414b2d9972f602d0c85191129d69c",
+                                              "size": 7346768
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-arm64"
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.4-nightly-20150209:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-arm64": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3/lwjgl2-natives-2.9.3-linux-arm64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-linux-arm64/lwjgl2-natives-2.9.3-linux-arm64.jar",
+                                              "sha1": "c47df34b6a0414b2d9972f602d0c85191129d69c",
+                                              "size": 7346768
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-arm64"
+                                        }
+                                      },
+                                      "net.java.jinput:jinput-platform:2.0.5:natives": null,
+                                      "com.mojang:text2speech:1.10.3:natives": null,
+                                      "com.mojang:text2speech:1.11.3:natives": null,
+                                      "com.mojang:text2speech:1.12.4:natives": null,
+                                      "com.mojang:text2speech:1.13.9:natives-linux": null
+                                    },
+                                    "linux-arm32": {
+                                      "org.lwjgl:lwjgl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl:3.2.3",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.2.3/lwjgl-3.2.3.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.2.3/lwjgl-3.2.3.jar",
+                                            "sha1": "17a59ba0fe8d474ec9dbe0d5db40d2cfe59c4c08",
+                                            "size": 552997
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl:3.2.3:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.2.3/lwjgl-3.2.3-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.2.3/lwjgl-3.2.3-natives-linux-arm32.jar",
+                                            "sha1": "3180d363040744dfe0c6a0dd5d018cedae476e9a",
+                                            "size": 53035
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.2.3",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.2.3/lwjgl-jemalloc-3.2.3.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.2.3/lwjgl-jemalloc-3.2.3.jar",
+                                            "sha1": "b6fd0932171ba3f2eaa4547beddca3a3e645342d",
+                                            "size": 34130
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.2.3:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.2.3/lwjgl-jemalloc-3.2.3-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.2.3/lwjgl-jemalloc-3.2.3-natives-linux-arm32.jar",
+                                            "sha1": "d7e5cecbf045b7b7863343273ffea94e0e2f6994",
+                                            "size": 137847
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.2.3",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.2.3/lwjgl-openal-3.2.3.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.2.3/lwjgl-openal-3.2.3.jar",
+                                            "sha1": "106742e805803ab9eab8e343f0fb31a3d263903c",
+                                            "size": 79432
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.2.3:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.2.3/lwjgl-openal-3.2.3-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.2.3/lwjgl-openal-3.2.3-natives-linux-arm32.jar",
+                                            "sha1": "5c30ef08c829252e542f9fbc04772d51013326c5",
+                                            "size": 552314
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.2.3",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.2.3/lwjgl-opengl-3.2.3.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.2.3/lwjgl-opengl-3.2.3.jar",
+                                            "sha1": "bdd534a323d0c8f54969b95e424b6ac8984f7d6e",
+                                            "size": 936589
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.2.3:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.2.3/lwjgl-opengl-3.2.3-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.2.3/lwjgl-opengl-3.2.3-natives-linux-arm32.jar",
+                                            "sha1": "4925362a5f2412cb6467e6d6c6de26b9e1ccfc71",
+                                            "size": 58594
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.2.3",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.2.3/lwjgl-glfw-3.2.3.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.2.3/lwjgl-glfw-3.2.3.jar",
+                                            "sha1": "5e520d5c290c8b012545a8d34fa5db5ab051ea53",
+                                            "size": 107999
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.2.3:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.2.3/lwjgl-glfw-3.2.3-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.2.3/lwjgl-glfw-3.2.3-natives-linux-arm32.jar",
+                                            "sha1": "aab1a5a1e21eca87f4acd5ba055f6bfd5d90951c",
+                                            "size": 138698
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.2.3",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.2.3/lwjgl-stb-3.2.3.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.2.3/lwjgl-stb-3.2.3.jar",
+                                            "sha1": "40eccaa4fa86fc815f2e17946a392fb5fdcc286a",
+                                            "size": 104049
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.2.3:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.2.3/lwjgl-stb-3.2.3-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.2.3/lwjgl-stb-3.2.3-natives-linux-arm32.jar",
+                                            "sha1": "f28dc1e73025cf699a2cdd4f6db7964ed357ce50",
+                                            "size": 146890
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.2.3",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.2.3/lwjgl-tinyfd-3.2.3.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.2.3/lwjgl-tinyfd-3.2.3.jar",
+                                            "sha1": "d5edf89c7b6ca1ea20865a6ba0a09bfc5efb29c1",
+                                            "size": 6392
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.2.3:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.2.3/lwjgl-tinyfd-3.2.3-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.2.3/lwjgl-tinyfd-3.2.3-natives-linux-arm32.jar",
+                                            "sha1": "b3ad16cb0e4c1307bf3d1ecb29559e18a4f8633c",
+                                            "size": 38752
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl:3.2.3",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.2.3/lwjgl-3.2.3.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.2.3/lwjgl-3.2.3.jar",
+                                            "sha1": "17a59ba0fe8d474ec9dbe0d5db40d2cfe59c4c08",
+                                            "size": 552997
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl:3.2.3:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.2.3/lwjgl-3.2.3-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.2.3/lwjgl-3.2.3-natives-linux-arm32.jar",
+                                            "sha1": "3180d363040744dfe0c6a0dd5d018cedae476e9a",
+                                            "size": 53035
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.2.3",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.2.3/lwjgl-jemalloc-3.2.3.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.2.3/lwjgl-jemalloc-3.2.3.jar",
+                                            "sha1": "b6fd0932171ba3f2eaa4547beddca3a3e645342d",
+                                            "size": 34130
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.2.3:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.2.3/lwjgl-jemalloc-3.2.3-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.2.3/lwjgl-jemalloc-3.2.3-natives-linux-arm32.jar",
+                                            "sha1": "d7e5cecbf045b7b7863343273ffea94e0e2f6994",
+                                            "size": 137847
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.2.3",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.2.3/lwjgl-openal-3.2.3.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.2.3/lwjgl-openal-3.2.3.jar",
+                                            "sha1": "106742e805803ab9eab8e343f0fb31a3d263903c",
+                                            "size": 79432
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.2.3:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.2.3/lwjgl-openal-3.2.3-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.2.3/lwjgl-openal-3.2.3-natives-linux-arm32.jar",
+                                            "sha1": "5c30ef08c829252e542f9fbc04772d51013326c5",
+                                            "size": 552314
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.2.3",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.2.3/lwjgl-opengl-3.2.3.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.2.3/lwjgl-opengl-3.2.3.jar",
+                                            "sha1": "bdd534a323d0c8f54969b95e424b6ac8984f7d6e",
+                                            "size": 936589
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.2.3:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.2.3/lwjgl-opengl-3.2.3-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.2.3/lwjgl-opengl-3.2.3-natives-linux-arm32.jar",
+                                            "sha1": "4925362a5f2412cb6467e6d6c6de26b9e1ccfc71",
+                                            "size": 58594
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.2.3",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.2.3/lwjgl-glfw-3.2.3.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.2.3/lwjgl-glfw-3.2.3.jar",
+                                            "sha1": "5e520d5c290c8b012545a8d34fa5db5ab051ea53",
+                                            "size": 107999
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.2.3:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.2.3/lwjgl-glfw-3.2.3-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.2.3/lwjgl-glfw-3.2.3-natives-linux-arm32.jar",
+                                            "sha1": "aab1a5a1e21eca87f4acd5ba055f6bfd5d90951c",
+                                            "size": 138698
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.2.3",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.2.3/lwjgl-stb-3.2.3.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.2.3/lwjgl-stb-3.2.3.jar",
+                                            "sha1": "40eccaa4fa86fc815f2e17946a392fb5fdcc286a",
+                                            "size": 104049
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.2.3:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.2.3/lwjgl-stb-3.2.3-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.2.3/lwjgl-stb-3.2.3-natives-linux-arm32.jar",
+                                            "sha1": "f28dc1e73025cf699a2cdd4f6db7964ed357ce50",
+                                            "size": 146890
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.2.3",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.2.3/lwjgl-tinyfd-3.2.3.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.2.3/lwjgl-tinyfd-3.2.3.jar",
+                                            "sha1": "d5edf89c7b6ca1ea20865a6ba0a09bfc5efb29c1",
+                                            "size": 6392
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.2.3:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.2.3/lwjgl-tinyfd-3.2.3-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.2.3/lwjgl-tinyfd-3.2.3-natives-linux-arm32.jar",
+                                            "sha1": "b3ad16cb0e4c1307bf3d1ecb29559e18a4f8633c",
+                                            "size": 38752
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl:3.3.1:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-linux-arm32.jar",
+                                            "sha1": "41a3c1dd15d6b964eb8196dde69720a3e3e5e969",
+                                            "size": 82374
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-linux-arm32.jar",
+                                            "sha1": "a96a6d6cb3876d7813fcee53c3c24f246aeba3b3",
+                                            "size": 136157
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-linux-arm32.jar",
+                                            "sha1": "ffbe35d7fa5ec9b7eca136a7c71f24d4025a510b",
+                                            "size": 400129
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-linux-arm32.jar",
+                                            "sha1": "e3550fa91097fd56e361b4370fa822220fef3595",
+                                            "size": 58474
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-linux-arm32.jar",
+                                            "sha1": "816d935933f2dd743074c4e717cc25b55720f294",
+                                            "size": 104027
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-linux-arm32.jar",
+                                            "sha1": "b08226bab162c06ae69337d8a1b0ee0a3fdf0b90",
+                                            "size": 153889
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-linux-arm32",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-linux-arm32.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-linux-arm32.jar",
+                                            "sha1": "d53d331e859217a61298fcbcf8d79137f3df345c",
+                                            "size": 48061
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.0:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-arm32": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3/lwjgl2-natives-2.9.3-linux-arm32.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-linux-arm32/lwjgl2-natives-2.9.3-linux-arm32.jar",
+                                              "sha1": "b3017961cf4ff2ce189b64903e52025a88ed9229",
+                                              "size": 580670
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-arm32"
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.1:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-arm32": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3/lwjgl2-natives-2.9.3-linux-arm32.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-linux-arm32/lwjgl2-natives-2.9.3-linux-arm32.jar",
+                                              "sha1": "b3017961cf4ff2ce189b64903e52025a88ed9229",
+                                              "size": 580670
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-arm32"
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.4-nightly-20150209:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-arm32": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3/lwjgl2-natives-2.9.3-linux-arm32.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-linux-arm32/lwjgl2-natives-2.9.3-linux-arm32.jar",
+                                              "sha1": "b3017961cf4ff2ce189b64903e52025a88ed9229",
+                                              "size": 580670
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-arm32"
+                                        }
+                                      },
+                                      "net.java.jinput:jinput-platform:2.0.5:natives": null,
+                                      "com.mojang:text2speech:1.10.3:natives": null,
+                                      "com.mojang:text2speech:1.11.3:natives": null,
+                                      "com.mojang:text2speech:1.12.4:natives": null,
+                                      "com.mojang:text2speech:1.13.9:natives-linux": null
+                                    },
+                                    "linux-mips64el": {
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.0:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc2",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-mips64el": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc2/lwjgl2-natives-2.9.3-rc2-linux-mips64el.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc2-linux-mips64el/lwjgl2-natives-2.9.3-rc2-linux-mips64el.jar",
+                                              "sha1": "8e96ae0b3ca2b566d4aa1ef737f1a11fde34636c",
+                                              "size": 947858
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-mips64el"
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.1:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc2",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-mips64el": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc2/lwjgl2-natives-2.9.3-rc2-linux-mips64el.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc2-linux-mips64el/lwjgl2-natives-2.9.3-rc2-linux-mips64el.jar",
+                                              "sha1": "8e96ae0b3ca2b566d4aa1ef737f1a11fde34636c",
+                                              "size": 947858
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-mips64el"
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.4-nightly-20150209:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc2",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-mips64el": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc2/lwjgl2-natives-2.9.3-rc2-linux-mips64el.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc2-linux-mips64el/lwjgl2-natives-2.9.3-rc2-linux-mips64el.jar",
+                                              "sha1": "8e96ae0b3ca2b566d4aa1ef737f1a11fde34636c",
+                                              "size": 947858
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-mips64el"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+                                            "size": 724243
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.1.6:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl3-natives:3.3.1-rc2",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-mips64el": {
+                                              "path": "org/glavo/hmcl/lwjgl3-natives/3.3.1-rc2/lwjgl3-natives-3.3.1-rc2-linux-mips64el.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl3-natives/3.3.1-rc2-linux-mips64el/lwjgl3-natives-3.3.1-rc2-linux-mips64el.jar",
+                                              "sha1": "babec61846d8feb7a60cce1c9909281b1a3e0640",
+                                              "size": 2464146
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-mips64el"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "sha1": "a817bcf213db49f710603677457567c37d53e103",
+                                            "size": 36601
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-openal:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+                                            "size": 88237
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-opengl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+                                            "size": 921563
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-glfw:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
+                                            "size": 128801
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-stb:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+                                            "size": 112380
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+                                            "size": 6767
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+                                            "size": 724243
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.2.2:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl3-natives:3.3.1-rc2",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-mips64el": {
+                                              "path": "org/glavo/hmcl/lwjgl3-natives/3.3.1-rc2/lwjgl3-natives-3.3.1-rc2-linux-mips64el.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl3-natives/3.3.1-rc2-linux-mips64el/lwjgl3-natives-3.3.1-rc2-linux-mips64el.jar",
+                                              "sha1": "babec61846d8feb7a60cce1c9909281b1a3e0640",
+                                              "size": 2464146
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-mips64el"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "sha1": "a817bcf213db49f710603677457567c37d53e103",
+                                            "size": 36601
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-openal:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+                                            "size": 88237
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-opengl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+                                            "size": 921563
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-glfw:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
+                                            "size": 128801
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-stb:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+                                            "size": 112380
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+                                            "size": 6767
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl:3.3.1:natives-linux": {
+                                        "name": "org.glavo.hmcl:lwjgl3-natives:3.3.1-rc2",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-mips64el": {
+                                              "path": "org/glavo/hmcl/lwjgl3-natives/3.3.1-rc2/lwjgl3-natives-3.3.1-rc2-linux-mips64el.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl3-natives/3.3.1-rc2-linux-mips64el/lwjgl3-natives-3.3.1-rc2-linux-mips64el.jar",
+                                              "sha1": "babec61846d8feb7a60cce1c9909281b1a3e0640",
+                                              "size": 2464146
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-mips64el"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-openal:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-opengl:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-glfw:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-stb:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-linux": null,
+                                      "net.java.jinput:jinput-platform:2.0.5:natives": null,
+                                      "com.mojang:text2speech:1.10.3:natives": null,
+                                      "com.mojang:text2speech:1.11.3:natives": null,
+                                      "com.mojang:text2speech:1.12.4:natives": null,
+                                      "com.mojang:text2speech:1.13.9:natives-linux": null
+                                    },
+                                    "linux-loongarch64": {
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.0:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc2",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-loongarch64": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc2/lwjgl2-natives-2.9.3-rc2-linux-loongarch64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc2-linux-loongarch64/lwjgl2-natives-2.9.3-rc2-linux-loongarch64.jar",
+                                              "sha1": "f4d42d89b31d8c6c60e847042e350883c2cdaa25",
+                                              "size": 623682
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-loongarch64"
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.1:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc2",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-loongarch64": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc2/lwjgl2-natives-2.9.3-rc2-linux-loongarch64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc2-linux-loongarch64/lwjgl2-natives-2.9.3-rc2-linux-loongarch64.jar",
+                                              "sha1": "f4d42d89b31d8c6c60e847042e350883c2cdaa25",
+                                              "size": 623682
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-loongarch64"
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.4-nightly-20150209:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc2",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-loongarch64": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc2/lwjgl2-natives-2.9.3-rc2-linux-loongarch64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc2-linux-loongarch64/lwjgl2-natives-2.9.3-rc2-linux-loongarch64.jar",
+                                              "sha1": "f4d42d89b31d8c6c60e847042e350883c2cdaa25",
+                                              "size": 623682
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-loongarch64"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+                                            "size": 724243
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.1.6:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl3-natives:3.3.1-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-loongarch64": {
+                                              "path": "org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1/lwjgl3-natives-3.3.1-rc1-linux-loongarch64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1-linux-loongarch64/lwjgl3-natives-3.3.1-rc1-linux-loongarch64.jar",
+                                              "sha1": "2375ec8e8094a765ef61f3c4f2f832b1b8dfed4b",
+                                              "size": 2651163
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-loongarch64"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "sha1": "a817bcf213db49f710603677457567c37d53e103",
+                                            "size": 36601
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-openal:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+                                            "size": 88237
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-opengl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+                                            "size": 921563
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-glfw:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
+                                            "size": 128801
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-stb:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+                                            "size": 112380
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+                                            "size": 6767
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+                                            "size": 724243
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.2.2:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl3-natives:3.3.1-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-loongarch64": {
+                                              "path": "org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1/lwjgl3-natives-3.3.1-rc1-linux-loongarch64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1-linux-loongarch64/lwjgl3-natives-3.3.1-rc1-linux-loongarch64.jar",
+                                              "sha1": "2375ec8e8094a765ef61f3c4f2f832b1b8dfed4b",
+                                              "size": 2651163
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-loongarch64"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "sha1": "a817bcf213db49f710603677457567c37d53e103",
+                                            "size": 36601
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-openal:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+                                            "size": 88237
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-opengl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+                                            "size": 921563
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-glfw:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
+                                            "size": 128801
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-stb:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+                                            "size": 112380
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+                                            "size": 6767
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl:3.3.1:natives-linux": {
+                                        "name": "org.glavo.hmcl:lwjgl3-natives:3.3.1-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-loongarch64": {
+                                              "path": "org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1/lwjgl3-natives-3.3.1-rc1-linux-loongarch64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1-linux-loongarch64/lwjgl3-natives-3.3.1-rc1-linux-loongarch64.jar",
+                                              "sha1": "2375ec8e8094a765ef61f3c4f2f832b1b8dfed4b",
+                                              "size": 2651163
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-loongarch64"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-openal:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-opengl:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-glfw:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-stb:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-linux": null,
+                                      "net.java.dev.jna:jna:5.8.0": {
+                                        "name": "net.java.dev.jna:jna:5.13.0",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar",
+                                            "url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar",
+                                            "sha1": "1200e7ebeedbe0d10062093f32925a912020e747",
+                                            "size": 1879325
+                                          }
+                                        }
+                                      },
+                                      "net.java.dev.jna:jna-platform:5.8.0": {
+                                        "name": "net.java.dev.jna:jna-platform:5.13.0",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0.jar",
+                                            "url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0.jar",
+                                            "sha1": "88e9a306715e9379f3122415ef4ae759a352640d",
+                                            "size": 1363209
+                                          }
+                                        }
+                                      },
+                                      "net.java.dev.jna:jna:5.10.0": {
+                                        "name": "net.java.dev.jna:jna:5.13.0",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar",
+                                            "url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar",
+                                            "sha1": "1200e7ebeedbe0d10062093f32925a912020e747",
+                                            "size": 1879325
+                                          }
+                                        }
+                                      },
+                                      "net.java.dev.jna:jna-platform:5.10.0": {
+                                        "name": "net.java.dev.jna:jna-platform:5.13.0",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0.jar",
+                                            "url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0.jar",
+                                            "sha1": "88e9a306715e9379f3122415ef4ae759a352640d",
+                                            "size": 1363209
+                                          }
+                                        }
+                                      },
+                                      "net.java.dev.jna:jna:5.12.1": {
+                                        "name": "net.java.dev.jna:jna:5.13.0",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar",
+                                            "url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar",
+                                            "sha1": "1200e7ebeedbe0d10062093f32925a912020e747",
+                                            "size": 1879325
+                                          }
+                                        }
+                                      },
+                                      "net.java.dev.jna:jna-platform:5.12.1": {
+                                        "name": "net.java.dev.jna:jna-platform:5.13.0",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0.jar",
+                                            "url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0.jar",
+                                            "sha1": "88e9a306715e9379f3122415ef4ae759a352640d",
+                                            "size": 1363209
+                                          }
+                                        }
+                                      },
+                                      "net.java.jinput:jinput-platform:2.0.5:natives": null,
+                                      "com.mojang:text2speech:1.10.3:natives": null,
+                                      "com.mojang:text2speech:1.11.3:natives": null,
+                                      "com.mojang:text2speech:1.12.4:natives": null,
+                                      "com.mojang:text2speech:1.13.9:natives-linux": null
+                                    },
+                                    "linux-loongarch64_ow": {
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.0:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-loongarch64": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1/lwjgl2-natives-2.9.3-rc1-linux-loongarch64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1-linux-loongarch64/lwjgl2-natives-2.9.3-rc1-linux-loongarch64.jar",
+                                              "sha1": "135e7e557431be70fa590eb6feffebb078d34728",
+                                              "size": 594335
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-loongarch64"
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.1:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-loongarch64": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1/lwjgl2-natives-2.9.3-rc1-linux-loongarch64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1-linux-loongarch64/lwjgl2-natives-2.9.3-rc1-linux-loongarch64.jar",
+                                              "sha1": "135e7e557431be70fa590eb6feffebb078d34728",
+                                              "size": 594335
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-loongarch64"
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.4-nightly-20150209:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-loongarch64": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1/lwjgl2-natives-2.9.3-rc1-linux-loongarch64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1-linux-loongarch64/lwjgl2-natives-2.9.3-rc1-linux-loongarch64.jar",
+                                              "sha1": "135e7e557431be70fa590eb6feffebb078d34728",
+                                              "size": 594335
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-loongarch64"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+                                            "size": 724243
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.1.6:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl3-natives:3.3.1-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-loongarch64_ow": {
+                                              "path": "org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1/lwjgl3-natives-3.3.1-rc1-linux-loongarch64_ow.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1-linux-loongarch64_ow/lwjgl3-natives-3.3.1-rc1-linux-loongarch64_ow.jar",
+                                              "sha1": "4c7d6978dae411e5041f478d78cc329c4c75fc73",
+                                              "size": 2311861
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-loongarch64_ow"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "sha1": "a817bcf213db49f710603677457567c37d53e103",
+                                            "size": 36601
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-openal:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+                                            "size": 88237
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-opengl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+                                            "size": 921563
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-glfw:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
+                                            "size": 128801
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-stb:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+                                            "size": 112380
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+                                            "size": 6767
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+                                            "size": 724243
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.2.2:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl3-natives:3.3.1-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-loongarch64_ow": {
+                                              "path": "org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1/lwjgl3-natives-3.3.1-rc1-linux-loongarch64_ow.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1-linux-loongarch64_ow/lwjgl3-natives-3.3.1-rc1-linux-loongarch64_ow.jar",
+                                              "sha1": "4c7d6978dae411e5041f478d78cc329c4c75fc73",
+                                              "size": 2311861
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-loongarch64_ow"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "sha1": "a817bcf213db49f710603677457567c37d53e103",
+                                            "size": 36601
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-openal:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+                                            "size": 88237
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-opengl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+                                            "size": 921563
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-glfw:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
+                                            "size": 128801
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-stb:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+                                            "size": 112380
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+                                            "size": 6767
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl:3.3.1:natives-linux": {
+                                        "name": "org.glavo.hmcl:lwjgl3-natives:3.3.1-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-loongarch64_ow": {
+                                              "path": "org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1/lwjgl3-natives-3.3.1-rc1-linux-loongarch64_ow.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1-linux-loongarch64_ow/lwjgl3-natives-3.3.1-rc1-linux-loongarch64_ow.jar",
+                                              "sha1": "4c7d6978dae411e5041f478d78cc329c4c75fc73",
+                                              "size": 2311861
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-loongarch64_ow"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-openal:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-opengl:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-glfw:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-stb:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-linux": null,
+                                      "net.java.dev.jna:jna:5.8.0": {
+                                        "name": "org.glavo.hmcl:jna:5.13.0-rc1-linux-loongarch64_ow",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/glavo/hmcl/jna/5.13.0-rc1-linux-loongarch64_ow/jna-5.13.0-rc1-linux-loongarch64_ow.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/jna/5.13.0-rc1-linux-loongarch64_ow/jna-5.13.0-rc1-linux-loongarch64_ow.jar",
+                                            "sha1": "42894c00949063f26752264288f2f2ab5179e21d",
+                                            "size": 1886827
+                                          }
+                                        }
+                                      },
+                                      "net.java.dev.jna:jna-platform:5.8.0": {
+                                        "name": "net.java.dev.jna:jna-platform:5.13.0",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0.jar",
+                                            "url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0.jar",
+                                            "sha1": "88e9a306715e9379f3122415ef4ae759a352640d",
+                                            "size": 1363209
+                                          }
+                                        }
+                                      },
+                                      "net.java.dev.jna:jna:5.10.0": {
+                                        "name": "org.glavo.hmcl:jna:5.13.0-rc1-linux-loongarch64_ow",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/glavo/hmcl/jna/5.13.0-rc1-linux-loongarch64_ow/jna-5.13.0-rc1-linux-loongarch64_ow.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/jna/5.13.0-rc1-linux-loongarch64_ow/jna-5.13.0-rc1-linux-loongarch64_ow.jar",
+                                            "sha1": "42894c00949063f26752264288f2f2ab5179e21d",
+                                            "size": 1886827
+                                          }
+                                        }
+                                      },
+                                      "net.java.dev.jna:jna-platform:5.10.0": {
+                                        "name": "net.java.dev.jna:jna-platform:5.13.0",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0.jar",
+                                            "url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0.jar",
+                                            "sha1": "88e9a306715e9379f3122415ef4ae759a352640d",
+                                            "size": 1363209
+                                          }
+                                        }
+                                      },
+                                      "net.java.dev.jna:jna:5.12.1": {
+                                        "name": "org.glavo.hmcl:jna:5.13.0-rc1-linux-loongarch64_ow",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/glavo/hmcl/jna/5.13.0-rc1-linux-loongarch64_ow/jna-5.13.0-rc1-linux-loongarch64_ow.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/jna/5.13.0-rc1-linux-loongarch64_ow/jna-5.13.0-rc1-linux-loongarch64_ow.jar",
+                                            "sha1": "42894c00949063f26752264288f2f2ab5179e21d",
+                                            "size": 1886827
+                                          }
+                                        }
+                                      },
+                                      "net.java.dev.jna:jna-platform:5.12.1": {
+                                        "name": "net.java.dev.jna:jna-platform:5.13.0",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0.jar",
+                                            "url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0.jar",
+                                            "sha1": "88e9a306715e9379f3122415ef4ae759a352640d",
+                                            "size": 1363209
+                                          }
+                                        }
+                                      },
+                                      "net.java.jinput:jinput-platform:2.0.5:natives": null,
+                                      "com.mojang:text2speech:1.10.3:natives": null,
+                                      "com.mojang:text2speech:1.11.3:natives": null,
+                                      "com.mojang:text2speech:1.12.4:natives": null,
+                                      "com.mojang:text2speech:1.13.9:natives-linux": null
+                                    },
+                                    "linux-riscv64": {
+                                      "org.lwjgl:lwjgl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+                                            "size": 724243
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.1.6:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl3-natives:3.3.1-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-riscv64": {
+                                              "path": "org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1/lwjgl3-natives-3.3.1-rc1-linux-riscv64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1-linux-riscv64/lwjgl3-natives-3.3.1-rc1-linux-riscv64.jar",
+                                              "sha1": "8544853aa77b10692548b2a728cd890afd740ba5",
+                                              "size": 11905844
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-riscv64"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "sha1": "a817bcf213db49f710603677457567c37d53e103",
+                                            "size": 36601
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-openal:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+                                            "size": 88237
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-opengl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+                                            "size": 921563
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-glfw:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
+                                            "size": 128801
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-stb:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+                                            "size": 112380
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+                                            "size": 6767
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6:natives": null,
+                                      "org.lwjgl:lwjgl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+                                            "size": 724243
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.2.2:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl3-natives:3.3.1-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-riscv64": {
+                                              "path": "org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1/lwjgl3-natives-3.3.1-rc1-linux-riscv64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1-linux-riscv64/lwjgl3-natives-3.3.1-rc1-linux-riscv64.jar",
+                                              "sha1": "8544853aa77b10692548b2a728cd890afd740ba5",
+                                              "size": 11905844
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-riscv64"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "sha1": "a817bcf213db49f710603677457567c37d53e103",
+                                            "size": 36601
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-openal:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+                                            "size": 88237
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-opengl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+                                            "size": 921563
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-glfw:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                                            "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
+                                            "size": 128801
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-stb:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+                                            "size": 112380
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+                                            "size": 6767
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2:natives": null,
+                                      "org.lwjgl:lwjgl:3.3.1:natives-linux": {
+                                        "name": "org.glavo.hmcl:lwjgl3-natives:3.3.1-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "linux-riscv64": {
+                                              "path": "org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1/lwjgl3-natives-3.3.1-rc1-linux-riscv64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1-linux-riscv64/lwjgl3-natives-3.3.1-rc1-linux-riscv64.jar",
+                                              "sha1": "8544853aa77b10692548b2a728cd890afd740ba5",
+                                              "size": 11905844
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "linux": "linux-riscv64"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-openal:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-opengl:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-glfw:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-stb:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-linux": null,
+                                      "org.lwjgl:lwjgl:3.3.2": {
+                                        "name": "org.lwjgl:lwjgl:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "7202012cf0cadb9ffad4874494920fd8bbd93413",
+                                            "size": 792204
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "2d38355b453edfe2daee1a567bcdb82c0485edcf",
+                                            "size": 95872
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.3.2": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "41256f2c098806304fd224613d3d01b02725470e",
+                                            "size": 46421
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "bdba1662b621228679c7aed87945d1f28c590d5b",
+                                            "size": 155867
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.3.2": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "89d8868c2d688b55e3e923345e4a146c6d034229",
+                                            "size": 113094
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "0fc6495e6752727b629cf03a105c9d56087d4edd",
+                                            "size": 597512
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.3.2": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "81d0a7fd96bf5eb6257fddf6b77e338d8918bf32",
+                                            "size": 931744
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "d3e8ec997cef8bc66819c7e0ad7a54182f7aff2a",
+                                            "size": 81034
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.3.2": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "e6dba9ab8532cb6aac273adf26496ce689999943",
+                                            "size": 146829
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "4881a965c7679b4984c0d8a5890f07ea85c653c4",
+                                            "size": 101847
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.3.2": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3.jar",
+                                            "sha1": "033fe42d1b37e35afd8b6e2653abc77deadb0730",
+                                            "size": 143099
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "sha1": "0aad82a857ebb9a3a212dc2c386761d57e11a8f2",
+                                            "size": 225735
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.3.2": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3.jar",
+                                            "sha1": "8b7c94a57f56a5b38b23c02c1cada77dccba9930",
+                                            "size": 15917
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "sha1": "124d0e48ae1584f09e5701588ae8ad139be26003",
+                                            "size": 39077
+                                          }
+                                        }
+                                      },
+                                      "net.java.jinput:jinput-platform:2.0.5:natives": null,
+                                      "com.mojang:text2speech:1.10.3:natives": null,
+                                      "com.mojang:text2speech:1.11.3:natives": null,
+                                      "com.mojang:text2speech:1.12.4:natives": null,
+                                      "com.mojang:text2speech:1.13.9:natives-linux": null
+                                    },
+                                    "windows-x86_64": {
+                                      "software-renderer-loader": {
+                                        "name": "org.glavo:llvmpipe-loader:1.0",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/glavo/llvmpipe-loader/1.0/llvmpipe-loader-1.0.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/glavo/llvmpipe-loader/1.0/llvmpipe-loader-1.0.jar",
+                                            "sha1": "ff255415e5c4b2a18970da0a8e552b557ca013ae",
+                                            "size": 12964773
+                                          }
+                                        }
+                                      },
+                                      "mesa-loader": {
+                                        "name": "org.glavo:mesa-loader-windows:0.2.0:x64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/glavo/mesa-loader-windows/0.2.0/mesa-loader-windows-0.2.0-x64.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/glavo/mesa-loader-windows/0.2.0/mesa-loader-windows-0.2.0-x64.jar",
+                                            "sha1": "adb4a16ecb95c8944a016829b05d70f934ea1a29",
+                                            "size": 22823052
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "windows-x86": {
+                                      "mesa-loader": {
+                                        "name": "org.glavo:mesa-loader-windows:0.2.0:x86",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/glavo/mesa-loader-windows/0.2.0/mesa-loader-windows-0.2.0-x86.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/glavo/mesa-loader-windows/0.2.0/mesa-loader-windows-0.2.0-x86.jar",
+                                            "sha1": "93c0b9b7382d984e713d3aa299ceb337fde2897b",
+                                            "size": 18273286
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "windows-arm64": {
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.0:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "windows-arm64": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1/lwjgl2-natives-2.9.3-rc1-windows-arm64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1-windows-arm64/lwjgl2-natives-2.9.3-rc1-windows-arm64.jar",
+                                              "sha1": "e0948a3692856d47854f3cd5a698d5c0233606d7",
+                                              "size": 617106
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "windows": "windows-arm64"
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.1:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "windows-arm64": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1/lwjgl2-natives-2.9.3-rc1-windows-arm64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1-windows-arm64/lwjgl2-natives-2.9.3-rc1-windows-arm64.jar",
+                                              "sha1": "e0948a3692856d47854f3cd5a698d5c0233606d7",
+                                              "size": 617106
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "windows": "windows-arm64"
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.4-nightly-20150209:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "windows-arm64": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1/lwjgl2-natives-2.9.3-rc1-windows-arm64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1-windows-arm64/lwjgl2-natives-2.9.3-rc1-windows-arm64.jar",
+                                              "sha1": "e0948a3692856d47854f3cd5a698d5c0233606d7",
+                                              "size": 617106
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "windows": "windows-arm64"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2.jar",
+                                            "sha1": "4421d94af68e35dcaa31737a6fc59136a1e61b94",
+                                            "size": 786196
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl:3.3.2:natives-windows-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-windows-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-windows-arm64.jar",
+                                            "sha1": "d900e4678449ba97ff46fa64b22e0376bf8cd00e",
+                                            "size": 133200
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2.jar",
+                                            "sha1": "877e17e39ebcd58a9c956dc3b5b777813de0873a",
+                                            "size": 43233
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.2:natives-windows-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-windows-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-windows-arm64.jar",
+                                            "sha1": "598790de603c286dbc4068b27829eacc37592786",
+                                            "size": 152780
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2.jar",
+                                            "sha1": "ae5357ed6d934546d3533993ea84c0cfb75eed95",
+                                            "size": 108230
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.2:natives-windows-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-windows-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-windows-arm64.jar",
+                                            "sha1": "545ddec7959007a78b6662d616e00dacf00e1c29",
+                                            "size": 627059
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2.jar",
+                                            "sha1": "ee8e95be0b438602038bc1f02dc5e3d011b1b216",
+                                            "size": 928871
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.2:natives-windows-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-windows-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-windows-arm64.jar",
+                                            "sha1": "21df035bf03dbf5001f92291b24dc951da513481",
+                                            "size": 83132
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2.jar",
+                                            "sha1": "757920418805fb90bfebb3d46b1d9e7669fca2eb",
+                                            "size": 135828
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.2:natives-windows-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-windows-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-windows-arm64.jar",
+                                            "sha1": "e79c4857a887bd79ba78bdf2d422a7d333028a2d",
+                                            "size": 141892
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2.jar",
+                                            "sha1": "a2550795014d622b686e9caac50b14baa87d2c70",
+                                            "size": 118874
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.2:natives-windows-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-windows-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-windows-arm64.jar",
+                                            "sha1": "c29df97c3cca97dc00d34e171936153764c9f78b",
+                                            "size": 218460
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2.jar",
+                                            "sha1": "9f65c248dd77934105274fcf8351abb75b34327c",
+                                            "size": 13404
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.2:natives-windows-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-windows-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-windows-arm64.jar",
+                                            "sha1": "500f5daa3b731ca282d4b90aeafda94c528d3e27",
+                                            "size": 110758
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2.jar",
+                                            "sha1": "4421d94af68e35dcaa31737a6fc59136a1e61b94",
+                                            "size": 786196
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl:3.3.2:natives-windows-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-windows-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-windows-arm64.jar",
+                                            "sha1": "d900e4678449ba97ff46fa64b22e0376bf8cd00e",
+                                            "size": 133200
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2.jar",
+                                            "sha1": "877e17e39ebcd58a9c956dc3b5b777813de0873a",
+                                            "size": 43233
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.2:natives-windows-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-windows-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-windows-arm64.jar",
+                                            "sha1": "598790de603c286dbc4068b27829eacc37592786",
+                                            "size": 152780
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2.jar",
+                                            "sha1": "ae5357ed6d934546d3533993ea84c0cfb75eed95",
+                                            "size": 108230
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.2:natives-windows-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-windows-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-windows-arm64.jar",
+                                            "sha1": "545ddec7959007a78b6662d616e00dacf00e1c29",
+                                            "size": 627059
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2.jar",
+                                            "sha1": "ee8e95be0b438602038bc1f02dc5e3d011b1b216",
+                                            "size": 928871
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.2:natives-windows-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-windows-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-windows-arm64.jar",
+                                            "sha1": "21df035bf03dbf5001f92291b24dc951da513481",
+                                            "size": 83132
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2.jar",
+                                            "sha1": "757920418805fb90bfebb3d46b1d9e7669fca2eb",
+                                            "size": 135828
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.2:natives-windows-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-windows-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-windows-arm64.jar",
+                                            "sha1": "e79c4857a887bd79ba78bdf2d422a7d333028a2d",
+                                            "size": 141892
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2.jar",
+                                            "sha1": "a2550795014d622b686e9caac50b14baa87d2c70",
+                                            "size": 118874
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.2:natives-windows-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-windows-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-windows-arm64.jar",
+                                            "sha1": "c29df97c3cca97dc00d34e171936153764c9f78b",
+                                            "size": 218460
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.2",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2.jar",
+                                            "sha1": "9f65c248dd77934105274fcf8351abb75b34327c",
+                                            "size": 13404
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.2:natives-windows-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-windows-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-windows-arm64.jar",
+                                            "sha1": "500f5daa3b731ca282d4b90aeafda94c528d3e27",
+                                            "size": 110758
+                                          }
+                                        }
+                                      },
+                                      "net.java.jinput:jinput-platform:2.0.5:natives": null,
+                                      "com.mojang:text2speech:1.10.3:natives": null,
+                                      "com.mojang:text2speech:1.11.3:natives": null,
+                                      "com.mojang:text2speech:1.12.4:natives": null,
+                                      "com.mojang:text2speech:1.13.9:natives-windows": null
+                                    },
+                                    "osx-arm64": {
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.1-nightly-20130708-debug3:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "osx-arm64": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1/lwjgl2-natives-2.9.3-rc1-osx-arm64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1-osx-arm64/lwjgl2-natives-2.9.3-rc1-osx-arm64.jar",
+                                              "sha1": "042ef2024a9a4054952c496c9ebcdb83345dabe0",
+                                              "size": 500107
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "osx": "osx-arm64"
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.1:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "osx-arm64": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1/lwjgl2-natives-2.9.3-rc1-osx-arm64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1-osx-arm64/lwjgl2-natives-2.9.3-rc1-osx-arm64.jar",
+                                              "sha1": "042ef2024a9a4054952c496c9ebcdb83345dabe0",
+                                              "size": 500107
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "osx": "osx-arm64"
+                                        }
+                                      },
+                                      "org.lwjgl.lwjgl:lwjgl-platform:2.9.2-nightly-20140822:natives": {
+                                        "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc1",
+                                        "downloads": {
+                                          "classifiers": {
+                                            "osx-arm64": {
+                                              "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1/lwjgl2-natives-2.9.3-rc1-osx-arm64.jar",
+                                              "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1-osx-arm64/lwjgl2-natives-2.9.3-rc1-osx-arm64.jar",
+                                              "sha1": "042ef2024a9a4054952c496c9ebcdb83345dabe0",
+                                              "size": 500107
+                                            }
+                                          }
+                                        },
+                                        "extract": {
+                                          "exclude": [
+                                            "META-INF/"
+                                          ]
+                                        },
+                                        "natives": {
+                                          "osx": "osx-arm64"
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+                                            "size": 724243
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl:3.3.1:natives-macos-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-macos-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-macos-arm64.jar",
+                                            "sha1": "71d0d5e469c9c95351eb949064497e3391616ac9",
+                                            "size": 42693
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "sha1": "a817bcf213db49f710603677457567c37d53e103",
+                                            "size": 36601
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-macos-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-macos-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-macos-arm64.jar",
+                                            "sha1": "e577b87d8ad2ade361aaea2fcf226c660b15dee8",
+                                            "size": 103475
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+                                            "size": 88237
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-macos-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-macos-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-macos-arm64.jar",
+                                            "sha1": "23d55e7490b57495320f6c9e1936d78fd72c4ef8",
+                                            "size": 346125
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+                                            "size": 921563
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-macos-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-macos-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-macos-arm64.jar",
+                                            "sha1": "eafe34b871d966292e8db0f1f3d6b8b110d4e91d",
+                                            "size": 41665
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.1.6": {
+                                        "name": "org.glavo.hmcl.mmachina:lwjgl-glfw:3.3.1-mmachina.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/glavo/hmcl/mmachina/lwjgl-glfw/3.3.1-mmachina.1/lwjgl-glfw-3.3.1-mmachina.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/mmachina/lwjgl-glfw/3.3.1-mmachina.1/lwjgl-glfw-3.3.1-mmachina.1.jar",
+                                            "sha1": "e9a101bca4fa30d26b21b526ff28e7c2d8927f1b",
+                                            "size": 130128
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-macos-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-macos-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-macos-arm64.jar",
+                                            "sha1": "cac0d3f712a3da7641fa174735a5f315de7ffe0a",
+                                            "size": 129077
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+                                            "size": 112380
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-macos-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-macos-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-macos-arm64.jar",
+                                            "sha1": "fcf073ed911752abdca5f0b00a53cfdf17ff8e8b",
+                                            "size": 178408
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+                                            "size": 6767
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-macos-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-macos-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-macos-arm64.jar",
+                                            "sha1": "972ecc17bad3571e81162153077b4d47b7b9eaa9",
+                                            "size": 41380
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.2.1": {
+                                        "name": "org.lwjgl:lwjgl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                                            "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+                                            "size": 724243
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.2.1:natives": {
+                                        "name": "org.lwjgl:lwjgl:3.3.1:natives-macos-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-macos-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-macos-arm64.jar",
+                                            "sha1": "71d0d5e469c9c95351eb949064497e3391616ac9",
+                                            "size": 42693
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.1": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                                            "sha1": "a817bcf213db49f710603677457567c37d53e103",
+                                            "size": 36601
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.1:natives": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-macos-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-macos-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-macos-arm64.jar",
+                                            "sha1": "e577b87d8ad2ade361aaea2fcf226c660b15dee8",
+                                            "size": 103475
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.2.1": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                                            "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+                                            "size": 88237
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.2.1:natives": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-macos-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-macos-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-macos-arm64.jar",
+                                            "sha1": "23d55e7490b57495320f6c9e1936d78fd72c4ef8",
+                                            "size": 346125
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.2.1": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                                            "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+                                            "size": 921563
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.2.1:natives": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-macos-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-macos-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-macos-arm64.jar",
+                                            "sha1": "eafe34b871d966292e8db0f1f3d6b8b110d4e91d",
+                                            "size": 41665
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.2.1": {
+                                        "name": "org.glavo.hmcl.mmachina:lwjgl-glfw:3.3.1-mmachina.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/glavo/hmcl/mmachina/lwjgl-glfw/3.3.1-mmachina.1/lwjgl-glfw-3.3.1-mmachina.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/mmachina/lwjgl-glfw/3.3.1-mmachina.1/lwjgl-glfw-3.3.1-mmachina.1.jar",
+                                            "sha1": "e9a101bca4fa30d26b21b526ff28e7c2d8927f1b",
+                                            "size": 130128
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.2.1:natives": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-macos-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-macos-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-macos-arm64.jar",
+                                            "sha1": "cac0d3f712a3da7641fa174735a5f315de7ffe0a",
+                                            "size": 129077
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.2.1": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                                            "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+                                            "size": 112380
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.2.1:natives": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-macos-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-macos-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-macos-arm64.jar",
+                                            "sha1": "fcf073ed911752abdca5f0b00a53cfdf17ff8e8b",
+                                            "size": 178408
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.1": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                                            "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+                                            "size": 6767
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.1:natives": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-macos-arm64",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-macos-arm64.jar",
+                                            "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-macos-arm64.jar",
+                                            "sha1": "972ecc17bad3571e81162153077b4d47b7b9eaa9",
+                                            "size": 41380
+                                          }
+                                        }
+                                      },
+                                      "ca.weblite:java-objc-bridge:1.0.0": {
+                                        "name": "org.glavo.hmcl.mmachina:java-objc-bridge:1.1.0-mmachina.1",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/glavo/hmcl/mmachina/java-objc-bridge/1.1.0-mmachina.1/java-objc-bridge-1.1.0-mmachina.1.jar",
+                                            "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/mmachina/java-objc-bridge/1.1.0-mmachina.1/java-objc-bridge-1.1.0-mmachina.1.jar",
+                                            "sha1": "369a83621e3c65496348491e533cb97fe5f2f37d",
+                                            "size": 91947
+                                          }
+                                        }
+                                      },
+                                      "ca.weblite:java-objc-bridge:1.0.0:natives": null,
+                                      "com.mojang:text2speech:1.10.3": {
+                                        "name": "com.mojang:text2speech:1.11.3",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "com/mojang/text2speech/1.11.3/text2speech-1.11.3.jar",
+                                            "url": "https://libraries.minecraft.net/com/mojang/text2speech/1.11.3/text2speech-1.11.3.jar",
+                                            "sha1": "f378f889797edd7df8d32272c06ca80a1b6b0f58",
+                                            "size": 13164
+                                          }
+                                        }
+                                      },
+                                      "net.java.jinput:jinput-platform:2.0.5:natives": null,
+                                      "com.mojang:text2speech:1.10.3:natives": null,
+                                      "com.mojang:text2speech:1.11.3:natives": null,
+                                      "com.mojang:text2speech:1.12.4:natives": null
+                                    },
+                                    "freebsd-x86_64": {
+                                      "org.lwjgl:lwjgl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "7202012cf0cadb9ffad4874494920fd8bbd93413",
+                                            "size": 792204
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "2d38355b453edfe2daee1a567bcdb82c0485edcf",
+                                            "size": 95872
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "41256f2c098806304fd224613d3d01b02725470e",
+                                            "size": 46421
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "bdba1662b621228679c7aed87945d1f28c590d5b",
+                                            "size": 155867
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "89d8868c2d688b55e3e923345e4a146c6d034229",
+                                            "size": 113094
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "0fc6495e6752727b629cf03a105c9d56087d4edd",
+                                            "size": 597512
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "81d0a7fd96bf5eb6257fddf6b77e338d8918bf32",
+                                            "size": 931744
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "d3e8ec997cef8bc66819c7e0ad7a54182f7aff2a",
+                                            "size": 81034
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "e6dba9ab8532cb6aac273adf26496ce689999943",
+                                            "size": 146829
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "4881a965c7679b4984c0d8a5890f07ea85c653c4",
+                                            "size": 101847
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3.jar",
+                                            "sha1": "033fe42d1b37e35afd8b6e2653abc77deadb0730",
+                                            "size": 143099
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "sha1": "0aad82a857ebb9a3a212dc2c386761d57e11a8f2",
+                                            "size": 225735
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3.jar",
+                                            "sha1": "8b7c94a57f56a5b38b23c02c1cada77dccba9930",
+                                            "size": 15917
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.1.6:natives": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "sha1": "124d0e48ae1584f09e5701588ae8ad139be26003",
+                                            "size": 39077
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "7202012cf0cadb9ffad4874494920fd8bbd93413",
+                                            "size": 792204
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "2d38355b453edfe2daee1a567bcdb82c0485edcf",
+                                            "size": 95872
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "41256f2c098806304fd224613d3d01b02725470e",
+                                            "size": 46421
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "bdba1662b621228679c7aed87945d1f28c590d5b",
+                                            "size": 155867
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "89d8868c2d688b55e3e923345e4a146c6d034229",
+                                            "size": 113094
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "0fc6495e6752727b629cf03a105c9d56087d4edd",
+                                            "size": 597512
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "81d0a7fd96bf5eb6257fddf6b77e338d8918bf32",
+                                            "size": 931744
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "d3e8ec997cef8bc66819c7e0ad7a54182f7aff2a",
+                                            "size": 81034
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "e6dba9ab8532cb6aac273adf26496ce689999943",
+                                            "size": 146829
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "4881a965c7679b4984c0d8a5890f07ea85c653c4",
+                                            "size": 101847
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3.jar",
+                                            "sha1": "033fe42d1b37e35afd8b6e2653abc77deadb0730",
+                                            "size": 143099
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "sha1": "0aad82a857ebb9a3a212dc2c386761d57e11a8f2",
+                                            "size": 225735
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3.jar",
+                                            "sha1": "8b7c94a57f56a5b38b23c02c1cada77dccba9930",
+                                            "size": 15917
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.2.2:natives": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "sha1": "124d0e48ae1584f09e5701588ae8ad139be26003",
+                                            "size": 39077
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.3.1": {
+                                        "name": "org.lwjgl:lwjgl:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "7202012cf0cadb9ffad4874494920fd8bbd93413",
+                                            "size": 792204
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "2d38355b453edfe2daee1a567bcdb82c0485edcf",
+                                            "size": 95872
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.3.1": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "41256f2c098806304fd224613d3d01b02725470e",
+                                            "size": 46421
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "bdba1662b621228679c7aed87945d1f28c590d5b",
+                                            "size": 155867
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.3.1": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "89d8868c2d688b55e3e923345e4a146c6d034229",
+                                            "size": 113094
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "0fc6495e6752727b629cf03a105c9d56087d4edd",
+                                            "size": 597512
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.3.1": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "81d0a7fd96bf5eb6257fddf6b77e338d8918bf32",
+                                            "size": 931744
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "d3e8ec997cef8bc66819c7e0ad7a54182f7aff2a",
+                                            "size": 81034
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.3.1": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "e6dba9ab8532cb6aac273adf26496ce689999943",
+                                            "size": 146829
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "4881a965c7679b4984c0d8a5890f07ea85c653c4",
+                                            "size": 101847
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.3.1": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3.jar",
+                                            "sha1": "033fe42d1b37e35afd8b6e2653abc77deadb0730",
+                                            "size": 143099
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "sha1": "0aad82a857ebb9a3a212dc2c386761d57e11a8f2",
+                                            "size": 225735
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.3.1": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3.jar",
+                                            "sha1": "8b7c94a57f56a5b38b23c02c1cada77dccba9930",
+                                            "size": 15917
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "sha1": "124d0e48ae1584f09e5701588ae8ad139be26003",
+                                            "size": 39077
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.3.2": {
+                                        "name": "org.lwjgl:lwjgl:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "7202012cf0cadb9ffad4874494920fd8bbd93413",
+                                            "size": 792204
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.4-SNAPSHOT/lwjgl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "2d38355b453edfe2daee1a567bcdb82c0485edcf",
+                                            "size": 95872
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.3.2": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "41256f2c098806304fd224613d3d01b02725470e",
+                                            "size": 46421
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-jemalloc:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-jemalloc:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.4-SNAPSHOT/lwjgl-jemalloc-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "bdba1662b621228679c7aed87945d1f28c590d5b",
+                                            "size": 155867
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.3.2": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "89d8868c2d688b55e3e923345e4a146c6d034229",
+                                            "size": 113094
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-openal:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-openal:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.4-SNAPSHOT/lwjgl-openal-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "0fc6495e6752727b629cf03a105c9d56087d4edd",
+                                            "size": 597512
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.3.2": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "81d0a7fd96bf5eb6257fddf6b77e338d8918bf32",
+                                            "size": 931744
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-opengl:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-opengl:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.4-SNAPSHOT/lwjgl-opengl-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "d3e8ec997cef8bc66819c7e0ad7a54182f7aff2a",
+                                            "size": 81034
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.3.2": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4.jar",
+                                            "sha1": "e6dba9ab8532cb6aac273adf26496ce689999943",
+                                            "size": 146829
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-glfw:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-glfw:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.4-SNAPSHOT/lwjgl-glfw-3.3.4-20231218.151521-4-natives-freebsd.jar",
+                                            "sha1": "4881a965c7679b4984c0d8a5890f07ea85c653c4",
+                                            "size": 101847
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.3.2": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3.jar",
+                                            "sha1": "033fe42d1b37e35afd8b6e2653abc77deadb0730",
+                                            "size": 143099
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-stb:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-stb:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.4-SNAPSHOT/lwjgl-stb-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "sha1": "0aad82a857ebb9a3a212dc2c386761d57e11a8f2",
+                                            "size": 225735
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.3.2": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.4-SNAPSHOT",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3.jar",
+                                            "sha1": "8b7c94a57f56a5b38b23c02c1cada77dccba9930",
+                                            "size": 15917
+                                          }
+                                        }
+                                      },
+                                      "org.lwjgl:lwjgl-tinyfd:3.3.2:natives-linux": {
+                                        "name": "org.lwjgl:lwjgl-tinyfd:3.3.4-SNAPSHOT:natives-freebsd",
+                                        "downloads": {
+                                          "artifact": {
+                                            "path": "org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "url": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.4-SNAPSHOT/lwjgl-tinyfd-3.3.4-20231218.151521-3-natives-freebsd.jar",
+                                            "sha1": "124d0e48ae1584f09e5701588ae8ad139be26003",
+                                            "size": 39077
+                                          }
+                                        }
+                                      },
+                                      "net.java.jinput:jinput-platform:2.0.5:natives": null,
+                                      "com.mojang:text2speech:1.10.3:natives": null,
+                                      "com.mojang:text2speech:1.11.3:natives": null,
+                                      "com.mojang:text2speech:1.12.4:natives": null,
+                                      "com.mojang:text2speech:1.13.9:natives-linux": null
+                                    }
+                                  }
+                                  """;
+}

--- a/ProjBobcat/ProjBobcat/Class/Helper/NativeReplace/NativeReplaceHelper.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/NativeReplace/NativeReplaceHelper.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using ProjBobcat.Class.Model;
+
+namespace ProjBobcat.Class.Helper.NativeReplace;
+
+public static partial class NativeReplaceHelper
+{
+    static readonly NativeReplaceModel NativeReplaceModel;
+
+    static NativeReplaceHelper()
+    {
+        var model = JsonSerializer.Deserialize(ReplaceDicJson, NativeReplaceModelContext.Default.NativeReplaceModel);
+
+        ArgumentNullException.ThrowIfNull(model);
+
+        NativeReplaceModel = model;
+    }
+
+    static string GetNativeKey()
+    {
+        var platform = NativeReplaceModel switch
+        {
+            _ when RuntimeInformation.IsOSPlatform(OSPlatform.Windows) => "windows",
+            _ when RuntimeInformation.IsOSPlatform(OSPlatform.Linux) => "linux",
+            _ when RuntimeInformation.IsOSPlatform(OSPlatform.OSX) => "osx",
+            _ when RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD) => "freebsd",
+            _ => string.Empty
+        };
+
+        var arch = NativeReplaceModel switch
+        {
+            _ when RuntimeInformation.OSArchitecture == Architecture.X64 => "x86_64",
+            _ when RuntimeInformation.OSArchitecture == Architecture.X86 => "x86",
+            _ when RuntimeInformation.OSArchitecture == Architecture.Arm64 => "arm64",
+            _ when RuntimeInformation.OSArchitecture == Architecture.Arm => "arm32",
+            _ when RuntimeInformation.OSArchitecture == Architecture.LoongArch64 => "loongarch64",
+            _ => string.Empty
+        };
+
+        return $"{platform}-{arch}";
+    }
+
+    public static List<Library> Replace(List<RawVersionModel> versions, List<Library> libs, NativeReplacementPolicy policy)
+    {
+        if (policy == NativeReplacementPolicy.Disabled) return libs;
+
+        var mcVersion = GameVersionHelper.TryGetMcVersion(versions);
+
+        if (string.IsNullOrEmpty(mcVersion) && policy == NativeReplacementPolicy.LegacyOnly) return libs;
+
+        var versionsArr = mcVersion?.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        var minor = -1;
+
+        if (versionsArr is { Length: 3 })
+        {
+            minor = int.TryParse(versionsArr[1], out var outMinor) ? outMinor : -1;
+        }
+
+        if (minor is -1 or >= 19 && policy == NativeReplacementPolicy.LegacyOnly) return libs;
+
+        var replaceKey = GetNativeKey();
+        var replaceDic = replaceKey switch
+        {
+            "windows-x86_64" => NativeReplaceModel.WindowsX64,
+            "windows-x86" => NativeReplaceModel.WindowsX86,
+            "windows-arm64" => NativeReplaceModel.WindowsArm64,
+            "linux-arm64" => NativeReplaceModel.LinuxArm64,
+            "linux-arm32" => NativeReplaceModel.LinuxArm86,
+            "linux-loongarch64" => NativeReplaceModel.LinuxLoongArch64,
+            "linux-loongarch64_ow" => NativeReplaceModel.LinuxLoongArch64Ow,
+            "osx-arm64" => NativeReplaceModel.OsxArm64,
+            "freebsd-x86_64" => NativeReplaceModel.FreeBsdX64,
+            _ => null
+        };
+
+        if (replaceDic == null) return libs;
+
+        var replaced = new List<Library>();
+        var filtered = libs.Where(lib => IsNotNative(lib.Name)).ToList();
+
+        foreach (var original in filtered)
+        {
+            var originalMaven = original.Name.ResolveMavenString();
+
+            if (originalMaven == null)
+            {
+                replaced.Add(original);
+                continue;
+            }
+
+            var isNative = original.IsNewNativeLib() ||
+                           (original.Natives?.Count ?? 0) > 0 ||
+                           original.Downloads?.Classifiers != null;
+            var candidateKey = isNative
+                ? $"{originalMaven.OrganizationName}:{originalMaven.ArtifactId}:{originalMaven.Version}:natives"
+                : original.Name;
+
+            replaced.Add(replaceDic.GetValueOrDefault(candidateKey, original));
+        }
+
+        return replaced;
+
+        static bool IsNotNative(string libName)
+        {
+            var maven = libName.ResolveMavenString();
+
+            if (maven == null) return true;
+
+            var isLwjgl = maven.OrganizationName == "org.lwjgl";
+            var isNative = maven.Classifier.StartsWith("natives", StringComparison.OrdinalIgnoreCase);
+            var isSpecialLwjglLib = maven.ArtifactId is "lwjgl-glfw" or "lwjgl-openal";
+
+            return !(isLwjgl && isNative && isSpecialLwjglLib);
+        }
+    }
+}

--- a/ProjBobcat/ProjBobcat/Class/Helper/NativeReplace/NativeReplaceHelper.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/NativeReplace/NativeReplaceHelper.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using ProjBobcat.Class.Model;
+using ProjBobcat.Class.Model.JsonContexts;
 
 namespace ProjBobcat.Class.Helper.NativeReplace;
 

--- a/ProjBobcat/ProjBobcat/Class/Helper/RulesHelper.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/RulesHelper.cs
@@ -10,6 +10,12 @@ namespace ProjBobcat.Class.Helper;
 /// </summary>
 public static class RulesHelper
 {
+    public static bool IsNewNativeLib(this Library lib)
+    {
+        return lib.Name.Contains("natives", StringComparison.OrdinalIgnoreCase) &&
+               lib.Downloads?.Artifact != null;
+    }
+
     /// <summary>
     ///     检查该Rule是否被允许
     /// </summary>

--- a/ProjBobcat/ProjBobcat/Class/Helper/TOMLParser/TommyExtensions.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/TOMLParser/TommyExtensions.cs
@@ -10,7 +10,7 @@ namespace ProjBobcat.Class.Helper.TOMLParser;
 /// <summary>
 ///     Class of various extension methods for Tommy
 /// </summary>
-public static class TommyExtensions
+public static partial class TommyExtensions
 {
     /// <summary>
     ///     Tries to parse TOML file.
@@ -26,13 +26,22 @@ public static class TommyExtensions
         try
         {
             rootNode = self.Parse();
-            errors = new List<TomlSyntaxException>();
+            errors = [];
             return true;
         }
         catch (TomlParseException ex)
         {
             rootNode = ex.ParsedTable;
             errors = ex.SyntaxErrors;
+            return false;
+        }
+        catch (Exception ex)
+        {
+            if (!ex.Message.StartsWith("The character", StringComparison.OrdinalIgnoreCase))
+                throw;
+
+            rootNode = null;
+            errors = [new TomlSyntaxException(ex.Message, TOMLParser.ParseState.None, 0, 0)];
             return false;
         }
     }

--- a/ProjBobcat/ProjBobcat/Class/LaunchWrapper.cs
+++ b/ProjBobcat/ProjBobcat/Class/LaunchWrapper.cs
@@ -16,7 +16,7 @@ namespace ProjBobcat.Class;
 ///     构造函数
 /// </remarks>
 /// <param name="authResult">验证结果</param>
-public class LaunchWrapper(AuthResultBase authResult) : IDisposable
+public class LaunchWrapper(AuthResultBase authResult, LaunchSettings launchSettings) : IDisposable
 {
     bool _disposedValue;
 
@@ -24,6 +24,11 @@ public class LaunchWrapper(AuthResultBase authResult) : IDisposable
     ///     验证结果
     /// </summary>
     public AuthResultBase AuthResult { get; } = authResult;
+
+    /// <summary>
+    /// 启动设置
+    /// </summary>
+    public LaunchSettings LaunchSettings { get; } = launchSettings;
 
     /// <summary>
     ///     退出码
@@ -125,6 +130,7 @@ public class LaunchWrapper(AuthResultBase authResult) : IDisposable
         if (GameCore is GameCoreBase coreBase)
             coreBase.OnLogGameData(sender, new GameLogEventArgs
             {
+                GameId = LaunchSettings.Version,
                 LogType = type,
                 RawContent = e.Data,
                 Content = e.Data[(totalPrefix?.Length ?? 0)..],

--- a/ProjBobcat/ProjBobcat/Class/Model/JsonContexts/JsonElementContext.cs
+++ b/ProjBobcat/ProjBobcat/Class/Model/JsonContexts/JsonElementContext.cs
@@ -5,6 +5,4 @@ namespace ProjBobcat.Class.Model.JsonContexts;
 
 [JsonSerializable(typeof(JsonElement))]
 [JsonSerializable(typeof(JsonElement[]))]
-partial class JsonElementContext : JsonSerializerContext
-{
-}
+partial class JsonElementContext : JsonSerializerContext;

--- a/ProjBobcat/ProjBobcat/Class/Model/JsonContexts/NativeReplaceModelContext.cs
+++ b/ProjBobcat/ProjBobcat/Class/Model/JsonContexts/NativeReplaceModelContext.cs
@@ -1,0 +1,6 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ProjBobcat.Class.Model.JsonContexts;
+
+[JsonSerializable(typeof(NativeReplaceModel))]
+partial class NativeReplaceModelContext : JsonSerializerContext;

--- a/ProjBobcat/ProjBobcat/Class/Model/LauncherAccount/LauncherAccountModel.cs
+++ b/ProjBobcat/ProjBobcat/Class/Model/LauncherAccount/LauncherAccountModel.cs
@@ -16,6 +16,4 @@ public class LauncherAccountModel
 }
 
 [JsonSerializable(typeof(LauncherAccountModel))]
-partial class LauncherAccountModelContext : JsonSerializerContext
-{
-}
+public partial class LauncherAccountModelContext : JsonSerializerContext;

--- a/ProjBobcat/ProjBobcat/Class/Model/LauncherProfile/LauncherProfileModel.cs
+++ b/ProjBobcat/ProjBobcat/Class/Model/LauncherProfile/LauncherProfileModel.cs
@@ -15,6 +15,4 @@ public class LauncherProfileModel
 }
 
 [JsonSerializable(typeof(LauncherProfileModel))]
-partial class LauncherProfileModelContext : JsonSerializerContext
-{
-}
+public partial class LauncherProfileModelContext : JsonSerializerContext;

--- a/ProjBobcat/ProjBobcat/Class/Model/NativeReplaceModel.cs
+++ b/ProjBobcat/ProjBobcat/Class/Model/NativeReplaceModel.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ProjBobcat.Class.Model;
+
+public class NativeReplaceModel
+{
+    [JsonPropertyName("linux-arm64")]
+    public required IReadOnlyDictionary<string, Library> LinuxArm64 { get; init; }
+
+    [JsonPropertyName("linux-arm32")]
+    public required IReadOnlyDictionary<string, Library> LinuxArm86 { get; init; }
+
+    [JsonPropertyName("linux-mips64el")]
+    public required IReadOnlyDictionary<string, Library> LinuxMips64El { get; init; }
+
+    [JsonPropertyName("linux-loongarch64")]
+    public required IReadOnlyDictionary<string, Library> LinuxLoongArch64 { get; init; }
+
+    [JsonPropertyName("linux-loongarch64_ow")]
+    public required IReadOnlyDictionary<string, Library> LinuxLoongArch64Ow { get; init; }
+
+    [JsonPropertyName("linux-riscv64")]
+    public required IReadOnlyDictionary<string, Library> LinuxRiscV64 { get; init; }
+
+    [JsonPropertyName("windows-x86_64")]
+    public required IReadOnlyDictionary<string, Library> WindowsX64 { get; init; }
+
+    [JsonPropertyName("windows-x86")]
+    public required IReadOnlyDictionary<string, Library> WindowsX86 { get; init; }
+
+    [JsonPropertyName("windows-arm64")]
+    public required IReadOnlyDictionary<string, Library> WindowsArm64 { get; init; }
+
+    [JsonPropertyName("osx-arm64")]
+    public required IReadOnlyDictionary<string, Library> OsxArm64 { get; init; }
+
+    [JsonPropertyName("freebsd-x86_64")]
+    public required IReadOnlyDictionary<string, Library> FreeBsdX64 { get; init; }
+}
+
+[JsonSerializable(typeof(NativeReplaceModel))]
+partial class NativeReplaceModelContext : JsonSerializerContext;

--- a/ProjBobcat/ProjBobcat/Class/Model/NativeReplaceModel.cs
+++ b/ProjBobcat/ProjBobcat/Class/Model/NativeReplaceModel.cs
@@ -38,6 +38,3 @@ public class NativeReplaceModel
     [JsonPropertyName("freebsd-x86_64")]
     public required IReadOnlyDictionary<string, Library?> FreeBsdX64 { get; init; }
 }
-
-[JsonSerializable(typeof(NativeReplaceModel))]
-partial class NativeReplaceModelContext : JsonSerializerContext;

--- a/ProjBobcat/ProjBobcat/Class/Model/NativeReplacementPolicy.cs
+++ b/ProjBobcat/ProjBobcat/Class/Model/NativeReplacementPolicy.cs
@@ -1,0 +1,8 @@
+﻿namespace ProjBobcat.Class.Model;
+
+public enum NativeReplacementPolicy
+{
+    Disabled,
+    LegacyOnly,
+    All
+}

--- a/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultVersionLocator.cs
+++ b/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultVersionLocator.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.Json;
 using ProjBobcat.Class;
 using ProjBobcat.Class.Helper;
+using ProjBobcat.Class.Helper.NativeReplace;
 using ProjBobcat.Class.Model;
 using ProjBobcat.Class.Model.JsonContexts;
 using ProjBobcat.Class.Model.LauncherProfile;
@@ -20,6 +21,8 @@ namespace ProjBobcat.DefaultComponent.Launch;
 /// </summary>
 public sealed class DefaultVersionLocator : VersionLocatorBase
 {
+    public NativeReplacementPolicy NativeReplacementPolicy { get; set; } = NativeReplacementPolicy.LegacyOnly;
+
     /// <summary>
     ///     构造函数。
     ///     Constructor.
@@ -552,6 +555,8 @@ public sealed class DefaultVersionLocator : VersionLocatorBase
                 rawLibs.Remove(sortedDuplicates[i]);
             }
         }
+
+        rawLibs = NativeReplaceHelper.Replace([rawVersion, ..inherits ?? []], rawLibs, NativeReplacementPolicy);
 
         var libs = GetNatives([.. rawLibs]);
 

--- a/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultVersionLocator.cs
+++ b/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultVersionLocator.cs
@@ -189,13 +189,12 @@ public sealed class DefaultVersionLocator : VersionLocatorBase
             // Different versions of Minecraft have different library JSON's structure.
 
             // Fix for new native format introduced in 1.19
-            if (lib.Name.Contains("natives", StringComparison.OrdinalIgnoreCase) &&
-                lib.Downloads?.Artifact != null)
+            if (lib.IsNewNativeLib())
             {
                 result.Item1.Add(new NativeFileInfo
                 {
                     Extract = lib.Extract,
-                    FileInfo = lib.Downloads.Artifact
+                    FileInfo = lib.Downloads!.Artifact!
                 });
 
                 continue;
@@ -471,7 +470,6 @@ public sealed class DefaultVersionLocator : VersionLocatorBase
                     result.Libraries.Add(mL);
                 }
 
-
                 var currentNativesNames = new List<string>(result.Natives
                     .Where(mL => !string.IsNullOrEmpty(mL.FileInfo.Name))
                     .Select(mL => mL.FileInfo.Name!));
@@ -523,10 +521,42 @@ public sealed class DefaultVersionLocator : VersionLocatorBase
             return result;
         }
 
-        var libs = GetNatives(rawVersion.Libraries);
+        var rawLibs = rawVersion.Libraries.ToList();
+        var duplicateLibs = new Dictionary<string, List<Library>>();
+        foreach (var lib in rawLibs)
+        {
+            var maven = lib.Name.ResolveMavenString();
+            var fullName = maven.GetMavenFullName();
+
+            if (duplicateLibs.TryGetValue(fullName, out var value))
+                value.Add(lib);
+            else
+                duplicateLibs.Add(fullName, [lib]);
+        }
+
+        var filteredLibs = duplicateLibs
+            .Select(p => p.Value
+                .Where(lib => !lib.IsNewNativeLib() && (lib.Natives?.Count ?? 0) == 0 && lib.Downloads?.Classifiers == null)
+                .Where(lib => lib.Rules?.CheckAllow() ?? true)
+                .ToList())
+            .Where(libs => libs.Count > 1);
+
+        foreach (var duplicates in filteredLibs)
+        {
+            var sortedDuplicates = duplicates
+                .OrderByDescending(l => new ComparableVersion(l.Name.ResolveMavenString()?.Version ?? "0"))
+                .ToList();
+
+            for (var i = 1; i < sortedDuplicates.Count; i++)
+            {
+                rawLibs.Remove(sortedDuplicates[i]);
+            }
+        }
+
+        var libs = GetNatives([.. rawLibs]);
+
         result.Libraries = libs.Item2;
         result.Natives = libs.Item1;
-
         result.JvmArguments = ParseJvmArguments(rawVersion.Arguments?.Jvm).ToList();
 
         var gameArgs =

--- a/ProjBobcat/ProjBobcat/DefaultComponent/Launch/GameCore/DefaultGameCore.cs
+++ b/ProjBobcat/ProjBobcat/DefaultComponent/Launch/GameCore/DefaultGameCore.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using ProjBobcat.Class;
@@ -313,7 +314,7 @@ public sealed class DefaultGameCore : GameCoreBase
 
             // arguments.ForEach(psi.ArgumentList.Add);
 
-            var launchWrapper = new LaunchWrapper(authResult)
+            var launchWrapper = new LaunchWrapper(authResult, settings)
             {
                 GameCore = this,
                 Process = Process.Start(psi)

--- a/ProjBobcat/ProjBobcat/DefaultComponent/ResourceInfoResolver/AssetInfoResolver.cs
+++ b/ProjBobcat/ProjBobcat/DefaultComponent/ResourceInfoResolver/AssetInfoResolver.cs
@@ -130,14 +130,26 @@ public sealed class AssetInfoResolver : ResolverBase
         catch (Exception ex)
         {
             OnResolve($"解析Asset Indexes 文件失败！原因：{ex.Message}");
-            File.Delete(assetIndexesPath);
+
+            try
+            {
+                File.Delete(assetIndexesPath);
+            }
+            catch (IOException) { }
+
             yield break;
         }
 
         if (assetObject == null)
         {
             OnResolve("解析Asset Indexes 文件失败！原因：文件可能损坏或为空");
-            File.Delete(assetIndexesPath);
+
+            try
+            {
+                File.Delete(assetIndexesPath);
+            }
+            catch (IOException) { }
+
             yield break;
         }
 

--- a/ProjBobcat/ProjBobcat/Event/GameLogEventArgs.cs
+++ b/ProjBobcat/ProjBobcat/Event/GameLogEventArgs.cs
@@ -5,6 +5,8 @@ namespace ProjBobcat.Event;
 
 public class GameLogEventArgs : EventArgs
 {
+    public string? GameId { get; set; }
+
     public GameLogType LogType { get; set; }
     public string? Time { get; set; }
     public string? Source { get; set; }

--- a/ProjBobcat/ProjBobcat/Platforms/Windows/DefaultMinecraftUWPCore.cs
+++ b/ProjBobcat/ProjBobcat/Platforms/Windows/DefaultMinecraftUWPCore.cs
@@ -47,7 +47,7 @@ public class DefaultMineCraftUWPCore : GameCoreBase
         /*using var process = new Process
             { StartInfo = psi };*/
 
-        var launchWrapper = new LaunchWrapper(null!)
+        var launchWrapper = new LaunchWrapper(null!, launchSettings)
         {
             GameCore = this,
             Process = uwpProcess!

--- a/ProjBobcat/ProjBobcat/Platforms/Windows/SystemInfoHelper.Windows.cs
+++ b/ProjBobcat/ProjBobcat/Platforms/Windows/SystemInfoHelper.Windows.cs
@@ -21,10 +21,14 @@ public static class SystemInfoHelper
 
     static SystemInfoHelper()
     {
-        // Performance Counter Pre-Heat
-        FreeMemCounter.NextValue();
-        MemUsagePercentageCounter.NextValue();
-        CpuCounter.NextValue();
+        try
+        {
+            // Performance Counter Pre-Heat
+            FreeMemCounter.NextValue();
+            MemUsagePercentageCounter.NextValue();
+            CpuCounter.NextValue();
+        }
+        catch (Exception) { }
     }
 
     /// <summary>
@@ -63,8 +67,8 @@ public static class SystemInfoHelper
         return SetAppxPackageInfoProperty(appxPackageInfo, values);
     }
 
-    static readonly string[] LineChArr = new[] { "\r\n", "\r", "\n" };
-    static readonly char[] SepArr = new[] { ':' };
+    static readonly string[] LineChArr = ["\r\n", "\r", "\n"];
+    static readonly char[] SepArr = [':'];
 
     /// <summary>
     ///     分析 PowerShell Get-AppxPackage 的输出。
@@ -154,7 +158,7 @@ public static class SystemInfoHelper
         {
             using var rootReg = Registry.LocalMachine.OpenSubKey("SOFTWARE");
 
-            if (rootReg == null) return Enumerable.Empty<string>();
+            if (rootReg == null) return [];
 
             using var wow64Reg = rootReg.OpenSubKey("Wow6432Node");
 
@@ -166,13 +170,13 @@ public static class SystemInfoHelper
         }
         catch
         {
-            return Enumerable.Empty<string>();
+            return [];
         }
     }
 
     public static IEnumerable<string> FindJavaInternal(RegistryKey? registry)
     {
-        if (registry == null) return Enumerable.Empty<string>();
+        if (registry == null) return [];
 
         try
         {
@@ -180,7 +184,7 @@ public static class SystemInfoHelper
             using var javaRuntimeReg = regKey?.OpenSubKey("Java Runtime Environment");
 
             if (javaRuntimeReg == null)
-                return Enumerable.Empty<string>();
+                return [];
 
             var result = new List<string>();
             foreach (var ver in javaRuntimeReg.GetSubKeyNames())
@@ -211,12 +215,19 @@ public static class SystemInfoHelper
     /// <returns></returns>
     public static MemoryInfo GetWindowsMemoryStatus()
     {
-        var free = FreeMemCounter.NextValue();
-        var total = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes / Math.Pow(1024, 2);
-        var used = total - free;
-        var percentage = MemUsagePercentageCounter.NextValue();
+        try
+        {
+            var free = FreeMemCounter.NextValue();
+            var total = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes / Math.Pow(1024, 2);
+            var used = total - free;
+            var percentage = MemUsagePercentageCounter.NextValue();
 
-        return new MemoryInfo(total, used, free, percentage);
+            return new MemoryInfo(total, used, free, percentage);
+        }
+        catch (Exception)
+        {
+            return new MemoryInfo(0, 0, 0, 0);
+        }
     }
 
     /// <summary>
@@ -225,12 +236,19 @@ public static class SystemInfoHelper
     /// <returns></returns>
     public static CPUInfo GetWindowsCpuUsage()
     {
-        var percentage = CpuCounter.NextValue();
-        var val = percentage > 100 ? 100 : percentage;
-
         const string name = "Total %";
 
-        return new CPUInfo(val, name);
+        try
+        {
+            var percentage = CpuCounter.NextValue();
+            var val = percentage > 100 ? 100 : percentage;
+
+            return new CPUInfo(val, name);
+        }
+        catch (Exception)
+        {
+            return new CPUInfo(0, name);
+        }
     }
 
     public static IEnumerable<string> GetLogicalDrives()

--- a/ProjBobcat/ProjBobcat/ProjBobcat.csproj
+++ b/ProjBobcat/ProjBobcat/ProjBobcat.csproj
@@ -64,7 +64,7 @@ resolved the issue that LaunchWrapper may not return the correct exit code
   <!-- Dependencies -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.2" />
     <PackageReference Include="SharpCompress">
       <Version>0.36.0</Version>
     </PackageReference>


### PR DESCRIPTION
- add support for legacy game natives replacement
- fix possible crashes for info resolver
- add support for auto-encoding detection for logs

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new enums, model classes, JSON contexts, encoding helpers, and game version parsing methods. It enhances JSON serialization, encoding detection, and Minecraft version extraction.

### Detailed summary
- Added `NativeReplacementPolicy` enum
- Modified `GameLogEventArgs` class
- Updated `DefaultMinecraftUWPCore` with `LaunchSettings`
- Refactored `UserPropertiesContext` JSON serialization
- Added `IsNewNativeLib` method to `RulesHelper`
- Updated JSON context classes
- Modified `AssetInfoResolver` for exception handling
- Updated `DefaultGameCore` with `Encoding` and `LaunchSettings`
- Added `NativeReplaceModel` class
- Added `EncodingHelper` for encoding detection
- Added `GameVersionHelper` for Minecraft version parsing

> The following files were skipped due to too many changes: `ProjBobcat/ProjBobcat/Class/Helper/GameVersionHelper.cs`, `ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultVersionLocator.cs`, `ProjBobcat/ProjBobcat/Class/Helper/NativeReplace/NativeReplaceHelper.cs`, `ProjBobcat/ProjBobcat/DefaultComponent/LogAnalysis/DefaultLogAnalyzer.cs`, `ProjBobcat/ProjBobcat/Class/Helper/GameResourcesResolveHelper.cs`, `ProjBobcat/ProjBobcat/Class/Helper/NativeReplace/NativeReplaceHelper.Json.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->