### PR TITLE
Fix LegacyForgeInstallProfile.cs

### DIFF
--- a/ProjBobcat/ProjBobcat/Class/Model/Forge/LegacyForgeInstallProfile.cs
+++ b/ProjBobcat/ProjBobcat/Class/Model/Forge/LegacyForgeInstallProfile.cs
@@ -63,7 +63,7 @@ public class VersionInfo
 
     [JsonPropertyName("assets")] public string? Assets { get; set; }
 
-    [JsonPropertyName("logging")] public JsonElement Logging { get; set; }
+    [JsonPropertyName("logging")] public JsonElement? Logging { get; set; }
 
     [JsonPropertyName("libraries")] public ForgeLibraries[] Libraries { get; set; } = [];
 }


### PR DESCRIPTION
Fix 1.7.10 forge bug

<!-- ProjBobcat Pull Request Standard Template 

## 预期目标 What does the pull request do
This PR fixes the MineCraft Forge 1.7.10 launch error



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `LegacyForgeInstallProfile` class to make the `Logging` property nullable.

### Detailed summary
- Updated `Logging` property in `LegacyForgeInstallProfile` to be nullable
- Changed type of `Logging` property from `JsonElement` to `JsonElement?`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->