### PR TITLE
improve game search

### DIFF
--- a/ProjBobcat/ProjBobcat/Class/Helper/GamePathHelper.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/GamePathHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Immutable;
 using System.IO;
 
 namespace ProjBobcat.Class.Helper;
@@ -42,22 +41,17 @@ public static class GamePathHelper
     /// <returns></returns>
     public static string GetGameJsonPath(string rootPath, string id)
     {
-        var dir = Path.Combine(rootPath, "versions", id);
-        var possibleFiles = Directory.EnumerateFiles(dir, "*.json").ToImmutableList();
-
-        if (possibleFiles.Count == 1) return possibleFiles[0];
-        if (possibleFiles.Count > 1)
+        var versions = Path.Combine(rootPath, "versions", id);
+        string? bestChoice = null;
+        foreach (var file in Directory.EnumerateFiles(versions, "*.json"))
         {
-            foreach (var file in possibleFiles)
-            {
-                var name = Path.GetFileNameWithoutExtension(file);
-
-                if (name.Equals(id, StringComparison.OrdinalIgnoreCase)) return file;
-                if (id.Contains(name, StringComparison.OrdinalIgnoreCase)) return file;
-            }
+            var name = Path.GetFileNameWithoutExtension(file);
+            if (name.Equals(id, StringComparison.OrdinalIgnoreCase))
+                return file;
+            if (bestChoice is not null && id.Contains(name, StringComparison.OrdinalIgnoreCase))
+                bestChoice = file;
         }
-
-        return Path.Combine(dir, $"{id}.json");
+        return bestChoice ?? Path.Combine(versions, $"{id}.json");
     }
 
     /// <summary>

--- a/ProjBobcat/ProjBobcat/Class/Helper/GamePathHelper.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/GamePathHelper.cs
@@ -43,13 +43,18 @@ public static class GamePathHelper
     {
         var versions = Path.Combine(rootPath, "versions", id);
         string? bestChoice = null;
+        bool notGoodEnough = true;
         foreach (var file in Directory.EnumerateFiles(versions, "*.json"))
         {
             var name = Path.GetFileNameWithoutExtension(file);
             if (name.Equals(id, StringComparison.OrdinalIgnoreCase))
                 return file;
-            if (bestChoice is not null && id.Contains(name, StringComparison.OrdinalIgnoreCase))
+
+            if (notGoodEnough)
+            {
                 bestChoice = file;
+                notGoodEnough = !id.Contains(name, StringComparison.OrdinalIgnoreCase);
+            }
         }
         return bestChoice ?? Path.Combine(versions, $"{id}.json");
     }

--- a/ProjBobcat/ProjBobcat/Class/Helper/GamePathHelper.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/GamePathHelper.cs
@@ -42,21 +42,19 @@ public static class GamePathHelper
     public static string GetGameJsonPath(string rootPath, string id)
     {
         var versions = Path.Combine(rootPath, "versions", id);
-        string? bestChoice = null;
-        bool notGoodEnough = true;
+
         foreach (var file in Directory.EnumerateFiles(versions, "*.json"))
         {
             var name = Path.GetFileNameWithoutExtension(file);
-            if (name.Equals(id, StringComparison.OrdinalIgnoreCase))
+
+            if (name.Contains(id, StringComparison.OrdinalIgnoreCase))
                 return file;
 
-            if (notGoodEnough)
-            {
-                bestChoice = file;
-                notGoodEnough = !id.Contains(name, StringComparison.OrdinalIgnoreCase);
-            }
+            if (id.Contains(name, StringComparison.OrdinalIgnoreCase))
+                return file;
         }
-        return bestChoice ?? Path.Combine(versions, $"{id}.json");
+
+        return Path.Combine(versions, $"{id}.json");
     }
 
     /// <summary>

--- a/ProjBobcat/ProjBobcat/Class/Helper/GamePathHelper.cs
+++ b/ProjBobcat/ProjBobcat/Class/Helper/GamePathHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Immutable;
 using System.IO;
 
 namespace ProjBobcat.Class.Helper;
@@ -41,7 +42,22 @@ public static class GamePathHelper
     /// <returns></returns>
     public static string GetGameJsonPath(string rootPath, string id)
     {
-        return Path.Combine(rootPath, "versions", id, $"{id}.json");
+        var dir = Path.Combine(rootPath, "versions", id);
+        var possibleFiles = Directory.EnumerateFiles(dir, "*.json").ToImmutableList();
+
+        if (possibleFiles.Count == 1) return possibleFiles[0];
+        if (possibleFiles.Count > 1)
+        {
+            foreach (var file in possibleFiles)
+            {
+                var name = Path.GetFileNameWithoutExtension(file);
+
+                if (name.Equals(id, StringComparison.OrdinalIgnoreCase)) return file;
+                if (id.Contains(name, StringComparison.OrdinalIgnoreCase)) return file;
+            }
+        }
+
+        return Path.Combine(dir, $"{id}.json");
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances `GetGameJsonPath` method in `GamePathHelper.cs` to search for JSON files by name case-insensitively before falling back to the default path creation logic.

### Detailed summary
- Improved `GetGameJsonPath` to search for JSON files by name case-insensitively
- Added logic to check for file names containing or contained in the provided id

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->