### PR TITLE
add support 1.8.8 and 1.8

### DIFF
--- a/ProjBobcat/ProjBobcat/DefaultComponent/Installer/ForgeInstaller/ForgeInstallerFactory.cs
+++ b/ProjBobcat/ProjBobcat/DefaultComponent/Installer/ForgeInstaller/ForgeInstallerFactory.cs
@@ -11,9 +11,12 @@ public static class ForgeInstallerFactory
     {
         var mcVer = new Version(mcVersion);
 
-        return mcVer.Minor is >= 7 and <= 8
-            ? $"{mcVersion}-{forgeVersion}-{mcVersion}"
-            : $"{mcVersion}-{forgeVersion}";
+        return (mcVer.Minor, mcVer.Build) switch
+        {
+            ( 8, 8 or -1) => $"{mcVersion}-{forgeVersion}", //1.8.8, 1.8
+            ( >= 7 and <= 8, _) => $"{mcVersion}-{forgeVersion}-{mcVersion}", //1.7 - 1.8, 1.8.9
+            _ => $"{mcVersion}-{forgeVersion}" //1.8.9+
+        };
     }
 
     public static bool IsLegacyForgeInstaller(string forgeExecutable, string forgeVersion)


### PR DESCRIPTION

What does the pull request do
     Add support legacy installer for 1.8.8 and 1.78 Forge 




<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the logic for generating Forge installation strings based on Minecraft version. 

### Detailed summary
- Refactored Forge installation string generation logic
- Added a switch statement to handle different Minecraft version scenarios
- Improved readability and maintainability of the code

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->