### PR TITLE
Fix MacOS ARM bug

### DIFF
--- a/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultVersionLocator.cs
+++ b/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultVersionLocator.cs
@@ -422,8 +422,10 @@ public sealed class DefaultVersionLocator : VersionLocatorBase
 
                 if (flag)
                 {
-                    var rootLibs = GetNatives(inherits[i]!.Libraries);
-
+                    var inheritsLibs = inherits[i]!.Libraries.ToList();
+                    inheritsLibs = NativeReplaceHelper.Replace([rawVersion, ..inherits ?? []], inheritsLibs, NativeReplacementPolicy);
+                    
+                    var rootLibs = GetNatives([.. inheritsLibs]);
                     result.Libraries = rootLibs.Item2;
                     result.Natives = rootLibs.Item1;
 


### PR DESCRIPTION
Fixing Natives loading errors. The Natives policy was not used in some cases, which does not allow installing libraries for ARM systems


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `DefaultVersionLocator` by optimizing library inheritance handling and native libraries retrieval.

### Detailed summary
- Replaced direct access to `GetNatives` with a more optimized approach
- Introduced `inheritsLibs` list to store inherited libraries
- Utilized `NativeReplaceHelper` for native library replacement
- Updated the assignment of `rootLibs` to consider `inheritsLibs` instead of direct access

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->