### PR TITLE
Adding a list of additional arguments for minecraft

### DIFF
--- a/ProjBobcat/ProjBobcat/Class/Model/LaunchSettings.cs
+++ b/ProjBobcat/ProjBobcat/Class/Model/LaunchSettings.cs
@@ -18,6 +18,7 @@ public class GameArguments
     public ResolutionModel? Resolution { get; set; }
     public required GcType GcType { get; init; }
     public IReadOnlyList<string>? AdditionalJvmArguments { get; set; }
+    public IReadOnlyList<string>? AdditionalArguments { get; set; }
     public ServerSettings? ServerSettings { get; set; }
     public string? AdvanceArguments { get; set; }
 }

--- a/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultLaunchArgumentParser.cs
+++ b/ProjBobcat/ProjBobcat/DefaultComponent/Launch/DefaultLaunchArgumentParser.cs
@@ -365,6 +365,10 @@ public class DefaultLaunchArgumentParser : LaunchArgumentParserBase, IArgumentPa
             yield return "--height";
             yield return GameProfile.Resolution.Height.ToString();
         }
+        
+        if ((LaunchSettings.GameArguments?.AdditionalArguments?.Count ?? 0) > 0)
+            foreach (var arg in LaunchSettings.GameArguments?.AdditionalArguments!)
+                yield return arg;
 
         if (LaunchSettings.GameArguments?.ServerSettings == null &&
             LaunchSettings.FallBackGameArguments?.ServerSettings == null) yield break;


### PR DESCRIPTION
## 预期目标 What does the pull request do
Allows you to add additional arguments at startup to Minecraft (by type --quickPlayMultiplayer)

<!-- 以下部分将由 AI 自动生成 The following parts will be automatically generated by AI -->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add support for `AdditionalArguments` in `LaunchSettings` and parse them in `DefaultLaunchArgumentParser`.

### Detailed summary
- Added `AdditionalArguments` property in `LaunchSettings`
- Updated `DefaultLaunchArgumentParser` to parse `AdditionalArguments` if present

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->