### PR TITLE
Fix bug analyst in not isolation version

### DIFF
--- a/ProjBobcat/ProjBobcat/DefaultComponent/LogAnalysis/DefaultLogAnalyzer.cs
+++ b/ProjBobcat/ProjBobcat/DefaultComponent/LogAnalysis/DefaultLogAnalyzer.cs
@@ -113,7 +113,7 @@ public partial class DefaultLogAnalyzer : ILogAnalyzer
         var fullRootPath = Path.GetFullPath(RootPath);
         var versionPath = Path.Combine(fullRootPath, GamePathHelper.GetGamePath(GameId));
 
-        var crashReportDi = new DirectoryInfo(Path.Combine(versionPath, "crash-reports"));
+        var crashReportDi = new DirectoryInfo(Path.Combine(VersionIsolation ? versionPath : RootPath, "crash-reports"));
         if (crashReportDi.Exists)
             logFiles.AddRange(crashReportDi.GetFiles().Where(fi => fi.Extension is ".log" or ".txt"));
 
@@ -121,8 +121,8 @@ public partial class DefaultLogAnalyzer : ILogAnalyzer
         if (versionDi.Exists)
             logFiles.AddRange(versionDi.GetFiles().Where(fi => fi.Extension == ".log"));
 
-        logFiles.Add(new FileInfo(Path.Combine(versionPath, "logs", "latest.log")));
-        logFiles.Add(new FileInfo(Path.Combine(versionPath, "logs", "debug.log")));
+        logFiles.Add(new FileInfo(Path.Combine(VersionIsolation ? versionPath : RootPath, "logs", "latest.log")));
+        logFiles.Add(new FileInfo(Path.Combine(VersionIsolation ? versionPath : RootPath, "logs", "debug.log")));
 
         if (CustomLogFiles is { Count: > 0 })
             logFiles.AddRange(CustomLogFiles.Select(custom => new FileInfo(custom)));
@@ -134,7 +134,7 @@ public partial class DefaultLogAnalyzer : ILogAnalyzer
             var logType = GetLogFileType(log);
 
             if (logType == LogFileType.Unknown) continue;
-            
+
             var content = File.ReadAllText(log.FullName, Encoding.GetEncoding("GB2312"));
 
             if (string.IsNullOrWhiteSpace(content)) continue;


### PR DESCRIPTION
Bug fixes due to which the code analyzer cannot find the latest log if the version is not isolated

<!-- 以下部分将由 AI 自动生成 The following parts will be automatically generated by AI -->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the `DefaultLogAnalyzer.cs` file to enhance the handling of log file paths based on a new `VersionIsolation` condition, affecting how crash report and log file directories are constructed.

### Detailed summary
- Updated the `crashReportDi` initialization to consider `VersionIsolation` when determining the path.
- Modified the paths for adding `latest.log` and `debug.log` to use `VersionIsolation`.
- Ensured that the logic for log file retrieval remains consistent with the new path handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->