### PR TITLE
Update LibraryInfoResolver.cs

### DIFF
--- a/ProjBobcat/ProjBobcat/DefaultComponent/ResourceInfoResolver/LibraryInfoResolver.cs
+++ b/ProjBobcat/ProjBobcat/DefaultComponent/ResourceInfoResolver/LibraryInfoResolver.cs
@@ -17,7 +17,7 @@ public sealed class LibraryInfoResolver : ResolverBase
 {
     public IReadOnlyList<string> LibraryUriRoots { get; init; } = ["https://libraries.minecraft.net/"];
     public IReadOnlyList<string> ForgeUriRoots { get; init; } = ["https://files.minecraftforge.net/"];
-    public IReadOnlyList<string> FabricMavenUriRoots { get; init; } = ["https://maven.fabricmc.net"];
+    public IReadOnlyList<string> FabricMavenUriRoots { get; init; } = ["https://maven.fabricmc.net/"];
     public IReadOnlyList<string> ForgeMavenUriRoots { get; init; } = ["https://maven.minecraftforge.net/"];
     public IReadOnlyList<string> ForgeMavenOldUriRoots { get; init; } = ["https://files.minecraftforge.net/maven/"];
     public IReadOnlyList<string> QuiltMavenUriRoots { get; init; } = ["https://maven.quiltmc.org/repository/release/"];


### PR DESCRIPTION
Fix download Fabric error
The link is generated incorrectly and an error is caused that this url does not exist. 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `LibraryInfoResolver.cs` file by correcting the URI format for `FabricMavenUriRoots` and ensuring proper newline formatting at the end of the file.

### Detailed summary
- Updated `FabricMavenUriRoots` to include a trailing slash in the URI: from `https://maven.fabricmc.net` to `https://maven.fabricmc.net/`.
- Added a newline at the end of the file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->